### PR TITLE
0.1.1: proper `class` attribute support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tl"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["y21"]
 edition = "2018"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # tl
 tl is an efficient and easy to use HTML parser written in Rust.<br />
 It does minimal to no copying during parsing by borrowing parts of the input string.
-Additionally, it keeps track of parsed elements and stores elements with an `id` attribute
-in an internal HashMap, which makes `get_element_by_id` as well as `get_elements_by_class_name` very fast.
+Additionally, it keeps track of parsed elements and stores elements with an `id` attribute in an internal HashMap, which makes element lookups by ID/class name very fast.
 
 ## Examples
 Finding an element by its `id` attribute and printing the inner text:

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -40,7 +40,7 @@ impl<'a> Bytes<'a> {
 /// A trait for converting a type into Bytes
 pub trait AsBytes {
     /// Converts `self` to `Bytes`
-    fn as_bytes<'a>(&'a self) -> Bytes<'a>;
+    fn as_bytes(&self) -> Bytes<'_>;
 }
 
 impl AsBytes for String {

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -49,6 +49,12 @@ impl AsBytes for String {
     }
 }
 
+impl<'a> AsBytes for Bytes<'a> {
+    fn as_bytes(&self) -> Bytes<'a> {
+        self.clone()
+    }
+}
+
 macro_rules! asbytes_from_impl {
     ($t:ty) => {
         impl AsBytes for $t {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! It does minimal to no copying during parsing by borrowing parts of the input string.
 //! Additionally, it keeps track of parsed elements and stores elements with an `id` attribute
-//! in an internal HashMap, which makes `get_element_by_id` as well as `get_elements_by_class_name` very fast (`O(1)`).
+//! in an internal HashMap, which makes element lookups by ID/class name very fast.
 //!
 //! ## Examples
 //! Finding an element by its `id` attribute and printing the inner text:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,14 +7,12 @@
 //! ## Examples
 //! Finding an element by its `id` attribute and printing the inner text:
 //! ```rust
-//! fn main() {
-//!     let input = r#"<p id="text">Hello</p>"#;
-//!     let dom = tl::parse(input);
+//! let input = r#"<p id="text">Hello</p>"#;
+//! let dom = tl::parse(input);
 //!
-//!     let element = dom.get_element_by_id("text").expect("Failed to find element");
+//! let element = dom.get_element_by_id("text").expect("Failed to find element");
 //!
-//!     println!("Inner text: {}", element.inner_text());
-//! }
+//! println!("Inner text: {}", element.inner_text());
 //! ```
 //!
 //! ## Bytes

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -460,10 +460,10 @@ impl<'a> Parser<'a> {
                 };
 
                 let slice = stream.slice(last, idx);
-                if slice.len() > 0 {
+                if !slice.is_empty() {
                     self.classes
                         .entry(slice.into())
-                        .or_insert_with(|| Vec::new())
+                        .or_insert_with(Vec::new)
                         .push(element.clone());
                 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -274,7 +274,6 @@ impl<'a> Parser<'a> {
                 if k.eq(ID_ATTR) {
                     attributes.id = v.clone();
                 } else if k.eq(CLASS_ATTR) {
-                    // TODO: This isn't correct - `class` attribute is space delimited
                     attributes.class = v.clone();
                 }
 
@@ -428,10 +427,7 @@ impl<'a> Parser<'a> {
                     }
 
                     if let Some(class) = class {
-                        self.classes
-                            .entry(class.clone())
-                            .or_insert_with(|| Vec::new())
-                            .push(tag_rc.clone());
+                        self.process_class(class, tag_rc.clone());
                     }
                 }
 
@@ -441,6 +437,40 @@ impl<'a> Parser<'a> {
             }
         } else {
             Some(Rc::new(Node::Raw(self.read_to(&[b'<']).into())))
+        }
+    }
+
+    fn process_class(&mut self, class: &Bytes<'a>, element: Rc<Node<'a>>) {
+        let raw = class.raw();
+
+        let mut stream = Stream::new(raw);
+
+        let mut last = 0;
+
+        while !stream.is_eof() {
+            let cur = stream.current_unchecked();
+
+            let is_last_char = stream.idx == raw.len() - 1;
+
+            if util::is_strict_whitespace(*cur) || is_last_char {
+                let idx = if is_last_char {
+                    stream.idx + 1
+                } else {
+                    stream.idx
+                };
+
+                let slice = stream.slice(last, idx);
+                if slice.len() > 0 {
+                    self.classes
+                        .entry(slice.into())
+                        .or_insert_with(|| Vec::new())
+                        .push(element.clone());
+                }
+
+                last = idx + 1;
+            }
+
+            stream.idx += 1;
         }
     }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -102,6 +102,6 @@ impl<'a, T> Stream<'a, T> {
 
     /// Same as slice, but uses the current index + 1 as `to`
     pub fn slice_from(&self, from: usize) -> &'a [T] {
-        self.slice(from, self.idx + 1)
+        self.slice(from, self.idx)
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -20,7 +20,7 @@ fn inner_html() {
 #[test]
 fn children_len() {
     let dom = parse("<!-- element 1 --> <div><div>element 3</div></div>");
-    assert_eq!(dom.children().len(), 3);
+    assert_eq!(dom.children().len(), 2);
 }
 
 #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,3 +5,7 @@ pub fn is_ident(c: u8) -> bool {
         || c == b'-'
         || c == b'_'
 }
+
+pub fn is_strict_whitespace(c: u8) -> bool {
+    [b' '].contains(&c)
+}


### PR DESCRIPTION
- properly parses elements with multiple `class` attributes
- fixes a bug in `Stream` that made it read past its element when slicing