### PR TITLE
0.2.0: `tl::parse_owned()`, restructure internals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tl"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["y21"]
 edition = "2018"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,14 +22,14 @@
 //! `VDomGuard` takes ownership over the string, which means you don't have to keep the string around.
 //! ```rust
 //! // Notice how it takes ownership over the string:
-//! let dom_guard = tl::parse_owned(String::from(r#"<p id="text">Hello</p>"#));
-//! 
+//! let dom_guard = unsafe { tl::parse_owned(String::from(r#"<p id="text">Hello</p>"#)) };
+//!
 //! // Obtain reference to underlying VDom
 //! let dom = dom_guard.get_ref();
-//! 
+//!
 //! // Now, use `dom` as you would if it was a regular `VDom`
 //! let element = dom.get_element_by_id("text").expect("Failed to find element");
-//! 
+//!
 //! println!("Inner text: {}", element.inner_text());
 //! ```
 //!
@@ -49,11 +49,11 @@ mod vdom;
 
 pub use bytes::{AsBytes, Bytes};
 use parser::Parser;
-pub use parser::{Attributes, HTMLTag, HTMLVersion, Node, Tree};
+pub use parser::{tag::Attributes, tag::HTMLTag, HTMLVersion, tag::Node, Tree};
 pub use vdom::{VDom, VDomGuard};
 
 /// Parses the given input string
-/// 
+///
 /// This is the "entry point" and function you will call to parse HTML.
 /// The input string must be kept alive, and must outlive `VDom`.
 /// If you need an "owned" version that takes an input string and can be kept around forever,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,35 @@
 //! tl is an efficient and easy to use HTML parser written in Rust.
 //!
 //! It does minimal to no copying during parsing by borrowing parts of the input string.
-//! Additionally, it keeps track of parsed elements and stores elements with an `id` attribute
+//! Additionally, it keeps track of parsed elements and stores elements with an id attribute
 //! in an internal HashMap, which makes element lookups by ID/class name very fast.
 //!
 //! ## Examples
-//! Finding an element by its `id` attribute and printing the inner text:
+//! Finding an element by its id attribute and printing the inner text:
 //! ```rust
 //! let input = r#"<p id="text">Hello</p>"#;
 //! let dom = tl::parse(input);
 //!
 //! let element = dom.get_element_by_id("text").expect("Failed to find element");
 //!
+//! println!("Inner text: {}", element.inner_text());
+//! ```
+//!
+//! ## Owned DOM
+//! Calling `tl::parse()` returns a DOM struct that borrows from the input string, which means that the string must be kept alive.
+//! The input string must outlive this DOM. If this is not acceptable or you need to keep the DOM around for longer,
+//! consider using `tl::parse_owned()`.
+//! `VDomGuard` takes ownership over the string, which means you don't have to keep the string around.
+//! ```rust
+//! // Notice how it takes ownership over the string:
+//! let dom_guard = tl::parse_owned(String::from(r#"<p id="text">Hello</p>"#));
+//! 
+//! // Obtain reference to underlying VDom
+//! let dom = dom_guard.get_ref();
+//! 
+//! // Now, use `dom` as you would if it was a regular `VDom`
+//! let element = dom.get_element_by_id("text").expect("Failed to find element");
+//! 
 //! println!("Inner text: {}", element.inner_text());
 //! ```
 //!
@@ -32,11 +50,25 @@ mod vdom;
 pub use bytes::{AsBytes, Bytes};
 use parser::Parser;
 pub use parser::{Attributes, HTMLTag, HTMLVersion, Node, Tree};
-pub use vdom::VDom;
+pub use vdom::{VDom, VDomGuard};
 
 /// Parses the given input string
 /// 
-/// This is the "entry point" and function you will call to parse HTML
+/// This is the "entry point" and function you will call to parse HTML.
+/// The input string must be kept alive, and must outlive `VDom`.
+/// If you need an "owned" version that takes an input string and can be kept around forever,
+/// consider using `parse_owned()`.
 pub fn parse(input: &str) -> VDom<'_> {
     VDom::from(Parser::new(input).parse())
+}
+
+/// Parses the given input string and returns an owned, RAII guarded DOM
+///
+/// ## Safety
+/// This uses a lot of `unsafe` behind the scenes to create a self-referential-like struct.
+/// The given input string is first leaked and turned into raw pointer, and its lifetime will be promoted to 'static.
+/// Once `VDomGuard` goes out of scope, the string will be freed.
+/// It should not be possible to cause UB in its current form and might become a safe function in the future.
+pub unsafe fn parse_owned<'a>(input: String) -> VDomGuard<'a> {
+    VDomGuard::parse(input)
 }

--- a/src/parser/base.rs
+++ b/src/parser/base.rs
@@ -1,131 +1,8 @@
 use crate::bytes::Bytes;
 use crate::stream::Stream;
 use crate::util;
-use std::{borrow::Cow, collections::HashMap, rc::Rc};
-
-const OPENING_TAG: u8 = b'<';
-const END_OF_TAG: &[u8] = b"</";
-const SELF_CLOSING: &[u8] = b"/>";
-const COMMENT: &[u8] = b"--";
-const ID_ATTR: &[u8] = b"id";
-const CLASS_ATTR: &[u8] = b"class";
-const VOID_TAGS: &[&[u8]] = &[
-    b"area", b"base", b"br", b"col", b"embed", b"hr", b"img", b"input", b"keygen", b"link",
-    b"meta", b"param", b"source", b"track", b"wbr",
-];
-
-/// Stores all attributes of an HTML tag, as well as additional metadata such as `id` and `class`
-#[derive(Debug, Clone)]
-pub struct Attributes<'a> {
-    /// Raw attributes (maps attribute key to attribute value)
-    pub raw: HashMap<Bytes<'a>, Option<Bytes<'a>>>,
-    /// The ID of this HTML element, if present
-    pub id: Option<Bytes<'a>>,
-    /// A list of class names of this HTML element, if present
-    pub class: Option<Bytes<'a>>,
-}
-
-impl<'a> Attributes<'a> {
-    /// Creates a new `Attributes
-    pub(crate) fn new() -> Self {
-        Self {
-            raw: HashMap::new(),
-            id: None,
-            class: None,
-        }
-    }
-}
-
-/// Represents a single HTML element
-#[derive(Debug, Clone)]
-pub struct HTMLTag<'a> {
-    _name: Option<Bytes<'a>>,
-    _attributes: Attributes<'a>,
-    _children: Vec<Rc<Node<'a>>>,
-    _raw: Bytes<'a>,
-}
-
-impl<'a> HTMLTag<'a> {
-    /// Creates a new HTMLTag
-    pub(crate) fn new(
-        name: Option<Bytes<'a>>,
-        attr: Attributes<'a>,
-        children: Vec<Rc<Node<'a>>>,
-        raw: Bytes<'a>,
-    ) -> Self {
-        Self {
-            _name: name,
-            _attributes: attr,
-            _children: children,
-            _raw: raw,
-        }
-    }
-
-    /// Returns the contained markup
-    /// Equivalent to [Element#innerHTML](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML) in browsers)
-    pub fn inner_html(&self) -> &Bytes<'a> {
-        &self._raw
-    }
-
-    /// Returns the contained text of this element, excluding any markup
-    /// Equivalent to [Element#innerText](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerText) in browsers)
-    /// This function may not allocate memory for a new string as it can just return the part of the tag that doesn't have markup
-    /// For tags that *do* have more than one subnode, this will allocate memory
-    pub fn inner_text(&self) -> Cow<'a, str> {
-        let len = self._children.len();
-
-        if len == 0 {
-            // If there are no subnodes, we can just return a static, empty, string slice
-            return Cow::Borrowed("");
-        }
-
-        let first = &self._children[0];
-
-        if len == 1 {
-            match &**first {
-                Node::Tag(t) => return t.inner_text(),
-                Node::Raw(e) => return e.as_utf8_str(),
-                Node::Comment(_) => return Cow::Borrowed(""),
-            }
-        }
-
-        // If there are >1 nodes, we need to allocate a new string and push each inner_text in it
-        // TODO: check if String::with_capacity() is worth it
-        let mut s = String::from(first.inner_text());
-
-        for node in self._children.iter().skip(1) {
-            match &**node {
-                Node::Tag(t) => s.push_str(&t.inner_text()),
-                Node::Raw(e) => s.push_str(&e.as_utf8_str()),
-                Node::Comment(_) => { /* no op */ }
-            }
-        }
-
-        Cow::Owned(s)
-    }
-}
-
-/// An HTML Node
-#[derive(Debug, Clone)]
-pub enum Node<'a> {
-    /// A regular HTML element/tag
-    Tag(HTMLTag<'a>),
-    /// Raw text (no particular HTML element)
-    Raw(Bytes<'a>),
-    /// Comment (<!-- -->)
-    Comment(Bytes<'a>),
-}
-
-impl<'a> Node<'a> {
-    /// Returns the inner text of this node
-    pub fn inner_text(&self) -> Cow<'a, str> {
-        match self {
-            Node::Comment(_) => Cow::Borrowed(""),
-            Node::Raw(r) => r.as_utf8_str(),
-            Node::Tag(t) => t.inner_text(),
-        }
-    }
-}
+use std::{collections::HashMap, rc::Rc};
+use super::{constants, tag::{Attributes, HTMLTag, Node}};
 
 /// A list of shared HTML nodes
 pub type Tree<'a> = Vec<Rc<Node<'a>>>;
@@ -220,8 +97,8 @@ impl<'a> Parser<'a> {
         while !self.stream.is_eof() {
             let idx = self.stream.idx;
 
-            if self.stream.slice_len(idx, COMMENT.len()).eq(COMMENT) {
-                self.stream.idx += COMMENT.len();
+            if self.stream.slice_len(idx, constants::COMMENT.len()).eq(constants::COMMENT) {
+                self.stream.idx += constants::COMMENT.len();
 
                 let is_end_of_comment = self.stream.expect_and_skip_cond(b'>');
 
@@ -261,7 +138,7 @@ impl<'a> Parser<'a> {
 
             let cur = self.stream.current_unchecked();
 
-            if SELF_CLOSING.contains(cur) {
+            if constants::SELF_CLOSING.contains(cur) {
                 break;
             }
 
@@ -271,9 +148,9 @@ impl<'a> Parser<'a> {
 
                 let v: Option<Bytes<'a>> = v.map(Into::into);
 
-                if k.eq(ID_ATTR) {
+                if k.eq(constants::ID_ATTR) {
                     attributes.id = v.clone();
-                } else if k.eq(CLASS_ATTR) {
+                } else if k.eq(constants::CLASS_ATTR) {
                     attributes.class = v.clone();
                 }
 
@@ -298,11 +175,11 @@ impl<'a> Parser<'a> {
         if markup_declaration {
             let is_comment = self
                 .stream
-                .slice(self.stream.idx, self.stream.idx + COMMENT.len())
-                .eq(COMMENT);
+                .slice(self.stream.idx, self.stream.idx + constants::COMMENT.len())
+                .eq(constants::COMMENT);
 
             if is_comment {
-                self.stream.idx += COMMENT.len();
+                self.stream.idx += constants::COMMENT.len();
                 let comment = self.skip_comment()?;
 
                 // Comments are ignored, so we return no element
@@ -361,7 +238,7 @@ impl<'a> Parser<'a> {
 
         self.stream.expect_and_skip(b'>')?;
 
-        if VOID_TAGS.contains(&name) {
+        if constants::VOID_TAGS.contains(&name) {
             let raw = self.stream.slice_from(start);
 
             // Some HTML tags don't have contents (e.g. <br>),
@@ -380,9 +257,9 @@ impl<'a> Parser<'a> {
 
             let idx = self.stream.idx;
 
-            let slice = self.stream.slice(idx, idx + END_OF_TAG.len());
-            if slice.eq(END_OF_TAG) {
-                self.stream.idx += END_OF_TAG.len();
+            let slice = self.stream.slice(idx, idx + constants::END_OF_TAG.len());
+            if slice.eq(constants::END_OF_TAG) {
+                self.stream.idx += constants::END_OF_TAG.len();
                 let ident = self.read_ident()?;
 
                 if !ident.eq(name) {
@@ -415,7 +292,7 @@ impl<'a> Parser<'a> {
 
         let ch = self.stream.current_cpy()?;
 
-        if ch == OPENING_TAG {
+        if ch == constants::OPENING_TAG {
             if let Some(tag) = self.parse_tag(true) {
                 let tag_rc = Rc::new(tag);
 

--- a/src/parser/base.rs
+++ b/src/parser/base.rs
@@ -56,7 +56,7 @@ impl<'a> Parser<'a> {
                 return self.stream.slice_unchecked(start, end);
             }
 
-            self.stream.idx += 1;
+            self.stream.advance();
         }
 
         self.stream.slice_unchecked(start, self.stream.idx)
@@ -70,7 +70,7 @@ impl<'a> Parser<'a> {
                 break;
             }
 
-            self.stream.idx += 1;
+            self.stream.advance();
         }
     }
 
@@ -85,7 +85,7 @@ impl<'a> Parser<'a> {
                 return Some(self.stream.slice_unchecked(start, idx));
             }
 
-            self.stream.idx += 1;
+            self.stream.advance();
         }
 
         None
@@ -98,7 +98,7 @@ impl<'a> Parser<'a> {
             let idx = self.stream.idx;
 
             if self.stream.slice_len(idx, constants::COMMENT.len()).eq(constants::COMMENT) {
-                self.stream.idx += constants::COMMENT.len();
+                self.stream.advance_by(constants::COMMENT.len());
 
                 let is_end_of_comment = self.stream.expect_and_skip_cond(b'>');
 
@@ -107,7 +107,7 @@ impl<'a> Parser<'a> {
                 }
             }
 
-            self.stream.idx += 1;
+            self.stream.advance();
         }
 
         None
@@ -157,7 +157,7 @@ impl<'a> Parser<'a> {
                 attributes.raw.insert(k.into(), v);
             }
 
-            self.stream.idx += 1;
+            self.stream.advance();
         }
 
         attributes
@@ -179,7 +179,7 @@ impl<'a> Parser<'a> {
                 .eq(constants::COMMENT);
 
             if is_comment {
-                self.stream.idx += constants::COMMENT.len();
+                self.stream.advance_by(constants::COMMENT.len());
                 let comment = self.skip_comment()?;
 
                 // Comments are ignored, so we return no element
@@ -259,7 +259,7 @@ impl<'a> Parser<'a> {
 
             let slice = self.stream.slice(idx, idx + constants::END_OF_TAG.len());
             if slice.eq(constants::END_OF_TAG) {
-                self.stream.idx += constants::END_OF_TAG.len();
+                self.stream.advance_by(constants::END_OF_TAG.len());
                 let ident = self.read_ident()?;
 
                 if !ident.eq(name) {
@@ -347,7 +347,7 @@ impl<'a> Parser<'a> {
                 last = idx + 1;
             }
 
-            stream.idx += 1;
+            stream.advance();
         }
     }
 

--- a/src/parser/constants.rs
+++ b/src/parser/constants.rs
@@ -1,0 +1,10 @@
+pub const OPENING_TAG: u8 = b'<';
+pub const END_OF_TAG: &[u8] = b"</";
+pub const SELF_CLOSING: &[u8] = b"/>";
+pub const COMMENT: &[u8] = b"--";
+pub const ID_ATTR: &[u8] = b"id";
+pub const CLASS_ATTR: &[u8] = b"class";
+pub const VOID_TAGS: &[&[u8]] = &[
+    b"area", b"base", b"br", b"col", b"embed", b"hr", b"img", b"input", b"keygen", b"link",
+    b"meta", b"param", b"source", b"track", b"wbr",
+];

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,0 +1,5 @@
+pub mod constants;
+pub mod tag;
+pub mod base;
+
+pub use base::*;

--- a/src/parser/tag.rs
+++ b/src/parser/tag.rs
@@ -1,0 +1,125 @@
+use std::{borrow::Cow, collections::HashMap, rc::Rc};
+use crate::Bytes;
+
+/// Stores all attributes of an HTML tag, as well as additional metadata such as `id` and `class`
+#[derive(Debug, Clone)]
+pub struct Attributes<'a> {
+    /// Raw attributes (maps attribute key to attribute value)
+    pub raw: HashMap<Bytes<'a>, Option<Bytes<'a>>>,
+    /// The ID of this HTML element, if present
+    pub id: Option<Bytes<'a>>,
+    /// A list of class names of this HTML element, if present
+    pub class: Option<Bytes<'a>>,
+}
+
+impl<'a> Attributes<'a> {
+    /// Creates a new `Attributes
+    pub(crate) fn new() -> Self {
+        Self {
+            raw: HashMap::new(),
+            id: None,
+            class: None,
+        }
+    }
+}
+
+/// Represents a single HTML element
+#[derive(Debug, Clone)]
+pub struct HTMLTag<'a> {
+    pub(crate) _name: Option<Bytes<'a>>,
+    pub(crate) _attributes: Attributes<'a>,
+    pub(crate) _children: Vec<Rc<Node<'a>>>,
+    pub(crate) _raw: Bytes<'a>,
+}
+
+impl<'a> HTMLTag<'a> {
+    /// Creates a new HTMLTag
+    pub(crate) fn new(
+        name: Option<Bytes<'a>>,
+        attr: Attributes<'a>,
+        children: Vec<Rc<Node<'a>>>,
+        raw: Bytes<'a>,
+    ) -> Self {
+        Self {
+            _name: name,
+            _attributes: attr,
+            _children: children,
+            _raw: raw,
+        }
+    }
+
+    /// Returns the name of this HTML tag
+    pub fn name(&self) -> &Option<Bytes<'a>> {
+        &self._name
+    }
+
+    /// Returns attributes of this HTML tag
+    pub fn attributes(&self) -> &Attributes<'a> {
+        &self._attributes
+    }
+
+    /// Returns the contained markup
+    /// Equivalent to [Element#innerHTML](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML) in browsers)
+    pub fn inner_html(&self) -> &Bytes<'a> {
+        &self._raw
+    }
+
+    /// Returns the contained text of this element, excluding any markup
+    /// Equivalent to [Element#innerText](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerText) in browsers)
+    /// This function may not allocate memory for a new string as it can just return the part of the tag that doesn't have markup
+    /// For tags that *do* have more than one subnode, this will allocate memory
+    pub fn inner_text(&self) -> Cow<'a, str> {
+        let len = self._children.len();
+
+        if len == 0 {
+            // If there are no subnodes, we can just return a static, empty, string slice
+            return Cow::Borrowed("");
+        }
+
+        let first = &self._children[0];
+
+        if len == 1 {
+            match &**first {
+                Node::Tag(t) => return t.inner_text(),
+                Node::Raw(e) => return e.as_utf8_str(),
+                Node::Comment(_) => return Cow::Borrowed(""),
+            }
+        }
+
+        // If there are >1 nodes, we need to allocate a new string and push each inner_text in it
+        // TODO: check if String::with_capacity() is worth it
+        let mut s = String::from(first.inner_text());
+
+        for node in self._children.iter().skip(1) {
+            match &**node {
+                Node::Tag(t) => s.push_str(&t.inner_text()),
+                Node::Raw(e) => s.push_str(&e.as_utf8_str()),
+                Node::Comment(_) => { /* no op */ }
+            }
+        }
+
+        Cow::Owned(s)
+    }
+}
+
+/// An HTML Node
+#[derive(Debug, Clone)]
+pub enum Node<'a> {
+    /// A regular HTML element/tag
+    Tag(HTMLTag<'a>),
+    /// Raw text (no particular HTML element)
+    Raw(Bytes<'a>),
+    /// Comment (<!-- -->)
+    Comment(Bytes<'a>),
+}
+
+impl<'a> Node<'a> {
+    /// Returns the inner text of this node
+    pub fn inner_text(&self) -> Cow<'a, str> {
+        match self {
+            Node::Comment(_) => Cow::Borrowed(""),
+            Node::Raw(r) => r.as_utf8_str(),
+            Node::Tag(t) => t.inner_text(),
+        }
+    }
+}

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -47,6 +47,10 @@ impl<'a, T: Eq + Copy> Stream<'a, T> {
             .map(|c| c == expect)
             .unwrap_or(false)
     }
+
+    pub fn is_next(&self, expect: T) -> bool {
+        self.peek().map(|x| *x == expect).unwrap_or(false)
+    }
 }
 
 impl<'a, T> Stream<'a, T> {
@@ -66,6 +70,10 @@ impl<'a, T> Stream<'a, T> {
             self.idx += 1;
             c
         })
+    }
+
+    pub fn peek(&self) -> Option<&T> {
+        self.data.get(self.idx + 1)
     }
 
     /// Returns the current element, but panicks if out of bounds

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -18,7 +18,7 @@ impl<'a, T: Copy> Stream<'a, T> {
     }
     /// Returns a copy of the next element
     pub fn next_cpy(&mut self) -> Option<T> {
-        self.idx += 1;
+        self.advance();
         self.data.get(self.idx).copied()
     }
 }
@@ -34,7 +34,7 @@ impl<'a, T: Eq + Copy> Stream<'a, T> {
         let c = self.current_cpy()?;
 
         if expect.contains(&c) {
-            self.idx += 1;
+            self.advance();
             return Some(c);
         }
 
@@ -67,13 +67,21 @@ impl<'a, T> Stream<'a, T> {
     /// Returns the next element
     pub fn next(&mut self) -> Option<&T> {
         self.data.get(self.idx + 1).map(|c| {
-            self.idx += 1;
+            self.advance();
             c
         })
     }
 
     pub fn peek(&self) -> Option<&T> {
         self.data.get(self.idx + 1)
+    }
+
+    pub fn advance(&mut self) {
+        self.idx += 1;
+    }
+
+    pub fn advance_by(&mut self, step: usize) {
+        self.idx += step;
     }
 
     /// Returns the current element, but panicks if out of bounds

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,5 @@
+use crate::{HTMLTag, Node, parser::*};
 use crate::{parse, parse_owned};
-use crate::parser::*;
 
 fn force_as_tag<'a, 'b>(actual: &'a Node<'b>) -> &'a HTMLTag<'b> {
     match actual {
@@ -72,7 +72,9 @@ fn move_owned() {
 
     let guard = unsafe { parse_owned(input) };
 
-    fn move_me<T>(p: T) -> T { p }
+    fn move_me<T>(p: T) -> T {
+        p
+    }
 
     let guard = std::thread::spawn(|| guard).join().unwrap();
     let guard = move_me(guard);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::parse;
+use crate::{parse, parse_owned};
 use crate::parser::*;
 
 fn force_as_tag<'a, 'b>(actual: &'a Node<'b>) -> &'a HTMLTag<'b> {
@@ -49,4 +49,37 @@ fn nested_inner_text() {
     let el = force_as_tag(&dom.children()[0]);
 
     assert_eq!(el.inner_text(), "hello nested element");
+}
+
+#[test]
+fn owned_dom() {
+    let owned_dom = {
+        let input = String::from("<p id=\"test\">hello</p>");
+        let dom = unsafe { parse_owned(input) };
+        dom
+    };
+
+    let dom = owned_dom.get_ref();
+
+    let el = force_as_tag(&dom.children()[0]);
+
+    assert_eq!(el.inner_text(), "hello");
+}
+
+#[test]
+fn move_owned() {
+    let input = String::from("<p id=\"test\">hello</p>");
+
+    let guard = unsafe { parse_owned(input) };
+
+    fn move_me<T>(p: T) -> T { p }
+
+    let guard = std::thread::spawn(|| guard).join().unwrap();
+    let guard = move_me(guard);
+
+    let dom = guard.get_ref();
+
+    let el = force_as_tag(&dom.children()[0]);
+
+    assert_eq!(el.inner_text(), "hello");
 }

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -1,4 +1,4 @@
-use crate::parser::{Node, Parser, Tree};
+use crate::{Node, Parser, Tree};
 use crate::{bytes::AsBytes, parser::HTMLVersion};
 use std::{marker::PhantomData, rc::Rc};
 
@@ -47,7 +47,6 @@ impl<'a> VDom<'a> {
     }
 }
 
-
 /// A RAII guarded version of VDom
 ///
 /// The input string is freed once this struct goes out of scope.
@@ -59,7 +58,7 @@ pub struct VDomGuard<'a> {
     /// Wrapped VDom instance
     dom: VDom<'a>,
     /// PhantomData for self.dom
-    _phantom: PhantomData<&'a str>
+    _phantom: PhantomData<&'a str>,
 }
 
 // SAFETY: The string is leaked and pinned to a memory location
@@ -72,14 +71,14 @@ impl<'a> VDomGuard<'a> {
         let ptr = Box::into_raw(input.into_boxed_str());
 
         // SAFETY: Shortening the lifetime of the input string is fine, as it's `'static`
-        let input_extended: &'a str = unsafe { std::mem::transmute(ptr) };
+        let input_extended: &'a str = unsafe { &*ptr };
 
         let parser = Parser::new(input_extended).parse();
 
         Self {
             ptr,
             dom: VDom::from(parser),
-            _phantom: PhantomData
+            _phantom: PhantomData,
         }
     }
 }


### PR DESCRIPTION
- adds `tl::parse_owned()`
- adds `HTMLTag::name()` and `HTMLTag::attributes()`
- restructures internals (parser has its own mod)