### PR TITLE
performance improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "tl"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["y21"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 description = "html parser written in rust"
 repository = "https://github.com/y21/tl"
@@ -11,8 +11,6 @@ readme = "README.md"
 documentation = "https://docs.rs/tl"
 keywords = ["html", "parser"]
 categories = ["parser-implementations", "parsing"]
-exclude = [
-    ".github/*"
-]
+exclude = [".github/*"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Finding an element by its id attribute and printing the inner text:
 ```rust
 fn main() {
     let input = r#"<p id="text">Hello</p>"#;
-    let dom = tl::parse(input);
+    let dom = tl::parse(input, tl::ParserOptions::default());
     let parser = dom.parser();
     let element = dom.get_element_by_id("text")
         .expect("Failed to find element")
@@ -38,7 +38,7 @@ Iterating over the subnodes of an HTML document:
 ```rust
 fn main() {
     let input = r#"<div><img src="cool-image.png" /></div>"#;
-    let dom = tl::parse(input);
+    let dom = tl::parse(input, tl::ParserOptions::default());
     let img = dom.nodes()
         .iter()
         .find(|node| {

--- a/README.md
+++ b/README.md
@@ -1,22 +1,42 @@
 # tl
-tl is an efficient and easy to use HTML parser written in Rust.<br />
+tl is a very fast, zero-copy HTML parser written in pure Rust. <br />
 It does minimal to no copying during parsing by borrowing parts of the input string.
-Additionally, it keeps track of parsed elements and stores elements with an `id` attribute in an internal HashMap, which makes element lookups by ID/class name very fast.
 
-## Examples
-Finding an element by its `id` attribute and printing the inner text:
+## Design
+Due to the zero-copy nature of parsers, the string must be kept alive for the entire lifetime of the parser/dom.
+If this is not acceptable or simply not possible in your case, you can call `tl::parse_owned()`.
+This goes through the same steps as `tl::parse()` but returns an `OwnedVDom` instead of a `VDom`.
+The difference is that `OwnedVDom` carefully creates a self-referential struct in which it stores the input string, so you can keep the `OwnedVDom` as long as you want and move it around as much as you want.
+
+### `InlineVec` and `InlineHashMap`
+`InlineVec` is a wrapper around an array/vec capable of storing a small number of elements on the stack, and if it becomes too large it will move all elements to the heap. 
+This library makes use of this concept in multiple places. "Children" of nodes (subnodes) are stored in an `InlineVec`, because it turns out that very often HTML tags don't actually have that many direct subnodes. This has the advantage that most of the time, HTML tags are mostly entirely allocated on the stack.
+`InlineHashMap` is very similar to `InlineVec`, except that for a small collection, it actually stores the `(Key, Value)` pair in a regular stack-allocated array, and traverses this array when doing a key lookup without doing any sort of hashing. Turns out that hashing keys only pays off for larger collections. If the length is small, hashing may actually be slower than just going through a few elements.
+
+### `Bytes`
+Some functions return a `Bytes` struct, which is an internal struct that is used to borrow a part of the input string.
+This is mainly used over a raw `&[u8]` for its `Debug` implementation.
+
+## Usage
+The main function is `tl::parse()`. It accepts an HTML source code string and parses it. It is important to note that tl currently silently ignores tags that are invalid, sort of like browsers do. Sometimes, this means that large chunks of the HTML document do not appear in the resulting AST, although in the future this will likely be customizable, in case you need explicit error checking.
+
+Finding an element by its id attribute and printing the inner text:
 ```rust
 fn main() {
     let input = r#"<p id="text">Hello</p>"#;
     let dom = tl::parse(input);
-    let element = dom.get_element_by_id("text").expect("Failed to find element");
+    let parser = dom.parser();
+    let element = dom.get_element_by_id("text")
+        .expect("Failed to find element")
+        .get(parser)
+        .unwrap();
 
-    println!("Inner text: {}", element.inner_text());
+    println!("Inner text: {}", element.inner_text(parser));
 }
 ```
 Using `VDom::find_node()` to dynamically find a subnode.
-> Note: If the HTML tag has an `id` attribute that you can use,
-> you probably want to use `get_element_by_id` instead, as it does not iterate over the tree to find the element.
+> Note: If the HTML tag has an id attribute that you can use,
+> use `VDom::get_element_by_id` instead, as it does not iterate over the tree to find the element.
 ```rust
 fn main() {
     let input = r#"<div><img src="cool-image.png" /></div>"#;
@@ -37,6 +57,5 @@ fn main() {
 Add `tl` to your dependencies.
 ```toml
 [dependencies]
-tl = "0.2.1"
+tl = "0.3.0"
 ```
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # tl
 tl is a very fast, zero-copy HTML parser written in pure Rust. <br />
-It does minimal to no copying during parsing by borrowing parts of the input string.
 
 ## Design
 Due to the zero-copy nature of parsers, the string must be kept alive for the entire lifetime of the parser/dom.
@@ -34,21 +33,19 @@ fn main() {
     println!("Inner text: {}", element.inner_text(parser));
 }
 ```
-Using `VDom::find_node()` to dynamically find a subnode.
-> Note: If the HTML tag has an id attribute that you can use,
-> use `VDom::get_element_by_id` instead, as it does not iterate over the tree to find the element.
+
+Iterating over the subnodes of an HTML document:
 ```rust
 fn main() {
     let input = r#"<div><img src="cool-image.png" /></div>"#;
     let dom = tl::parse(input);
-    let element = dom.find_node(|node| {
-        node.as_tag()
-            .unwrap()
-            .attributes()
-            .raw
-            .contains_key(&"src".into())
-    });
-    println!("{:?}", element);
+    let img = dom.nodes()
+        .iter()
+        .find(|node| {
+            node.as_tag().map_or(false, |tag| tag.name() == &"img".into())
+        });
+    
+    println!("{:?}", img);
 }
 ```
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -37,6 +37,11 @@ impl<'a> Bytes<'a> {
     pub fn raw(&self) -> &'a [u8] {
         self.0
     }
+
+    /// Returns a read-only raw pointer to the inner data
+    pub fn as_ptr(&self) -> *const u8 {
+        self.0.as_ptr()
+    }
 }
 
 /// A trait for converting a type into Bytes

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -6,12 +6,14 @@ use std::borrow::Cow;
 pub struct Bytes<'a>(&'a [u8]);
 
 impl<'a> From<&'a str> for Bytes<'a> {
+    #[inline]
     fn from(s: &'a str) -> Self {
         Self(s.as_bytes())
     }
 }
 
 impl<'a> From<&'a [u8]> for Bytes<'a> {
+    #[inline]
     fn from(s: &'a [u8]) -> Self {
         Self(s)
     }

--- a/src/inline/hashmap.rs
+++ b/src/inline/hashmap.rs
@@ -1,0 +1,243 @@
+use std::fmt::{Debug, Formatter};
+use std::hash::Hash;
+use std::{collections::HashMap, mem::MaybeUninit};
+
+/// Similar to InlineVec, this structure will use an array
+/// if it is small enough to live on the stack, otherwise
+/// it allocates a HashMap on the heap
+///
+/// Hashing can be slower than just iterating through an array
+/// if the array is small, which is where it makes most sense
+// #[derive(Debug, Clone)]
+///
+/// To convert to a HashMap, use `HashMap::from()`
+pub enum InlineHashMap<K, V, const N: usize> {
+    /// Inline array
+    Inline {
+        /// Length of the array
+        len: usize,
+        /// Data stored in the array
+        data: [MaybeUninit<(K, V)>; N],
+    },
+    /// Heap allocated HashMap
+    Heap(HashMap<K, V>),
+}
+
+impl<K, V, const N: usize> Debug for InlineHashMap<K, V, N>
+where
+    K: Debug,
+    V: Debug,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "InlineHashMap<{} items>", self.len())
+    }
+}
+
+impl<K, V, const N: usize> Clone for InlineHashMap<K, V, N>
+where
+    K: Clone,
+    V: Clone,
+{
+    fn clone(&self) -> Self {
+        match self {
+            Self::Heap(m) => Self::Heap(m.clone()),
+            Self::Inline { len, data } => {
+                let mut new_data = super::uninit_array();
+
+                let iter = data.iter().take(*len).enumerate();
+
+                for (idx, element) in iter {
+                    let element = unsafe { &*element.as_ptr() };
+                    let (key, value) = element.clone();
+                    new_data[idx] = MaybeUninit::new((key, value));
+                }
+
+                Self::Inline {
+                    len: *len,
+                    data: new_data,
+                }
+            }
+        }
+    }
+}
+
+impl<K, V, const N: usize> From<InlineHashMap<K, V, N>> for HashMap<K, V>
+where
+    K: Eq + Hash,
+{
+    fn from(map: InlineHashMap<K, V, N>) -> Self {
+        match map {
+            InlineHashMap::Heap(m) => m,
+            InlineHashMap::Inline { len, data } => {
+                let mut new_data = HashMap::with_capacity(len);
+
+                let iter = data.into_iter().take(len);
+
+                for element in iter {
+                    let (k, v) = unsafe { element.assume_init() };
+                    new_data.insert(k, v);
+                }
+
+                new_data
+            }
+        }
+    }
+}
+
+impl<K, V, const N: usize> InlineHashMap<K, V, N> {
+    /// Creates a new InlineHashMap
+    #[inline]
+    pub fn new() -> Self {
+        Self::Inline {
+            len: 0,
+            data: super::uninit_array(),
+        }
+    }
+
+    /// Returns the length of this map
+    #[inline]
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Inline { len, .. } => *len,
+            Self::Heap(map) => map.len(),
+        }
+    }
+
+    /// Checks whether this vector is allocated on the heap
+    #[inline]
+    pub fn is_heap_allocated(&self) -> bool {
+        matches!(self, Self::Heap(_))
+    }
+}
+
+impl<K: Eq + Hash, V, const N: usize> InlineHashMap<K, V, N> {
+    /// Returns a reference to the value corresponding to the key.
+    pub fn get<'m>(&'m self, k: &K) -> Option<&'m V> {
+        match self {
+            Self::Inline { data, len } => unsafe {
+                InlineHashMapIterator::new(data, *len)
+                    .find(|(key, _)| key.eq(k))
+                    .map(|(_, value)| value)
+            },
+            Self::Heap(map) => map.get(k),
+        }
+    }
+
+    /// Inserts a key-value pair into the map.
+    pub fn insert(&mut self, k: K, v: V) {
+        let (array, len) = match self {
+            Self::Inline { data, len } => (data, len),
+            Self::Heap(map) => {
+                map.insert(k, v);
+                return;
+            }
+        };
+
+        if *len >= N {
+            let mut map = HashMap::with_capacity(*len);
+
+            // move old elements to heap
+            for element in array.iter_mut().take(*len) {
+                let element = std::mem::replace(element, MaybeUninit::uninit());
+                let (key, value) = unsafe { element.assume_init() };
+
+                map.insert(key, value);
+            }
+
+            // insert new element
+            map.insert(k, v);
+            *self = Self::Heap(map);
+            return;
+        } else {
+            array[*len].write((k, v));
+            *len += 1;
+        }
+    }
+
+    /// Returns true if the map contains a value for the specified key.
+    pub fn contains_key(&self, k: &K) -> bool {
+        match self {
+            Self::Inline { data, len } => unsafe {
+                InlineHashMapIterator::new(data, *len).any(|(key, _)| key.eq(k))
+            },
+            Self::Heap(map) => map.contains_key(k),
+        }
+    }
+}
+
+/// An iterator over the inline array elements of an `InlineHashMap`.
+pub struct InlineHashMapIterator<'a, K, V> {
+    array: &'a [MaybeUninit<(K, V)>],
+    idx: usize,
+    len: usize,
+}
+
+impl<'a, K, V> InlineHashMapIterator<'a, K, V> {
+    pub(crate) unsafe fn new(array: &'a [MaybeUninit<(K, V)>], len: usize) -> Self {
+        Self { array, idx: 0, len }
+    }
+}
+
+impl<'a, K, V> Iterator for InlineHashMapIterator<'a, K, V> {
+    type Item = &'a (K, V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.idx >= self.len {
+            return None;
+        }
+
+        let element = unsafe { &*self.array[self.idx].as_ptr() };
+        self.idx += 1;
+
+        Some(element)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inlinehashmap_clone() {
+        let mut x = InlineHashMap::<usize, usize, 4>::new();
+
+        for i in 0..10 {
+            x.insert(i, i * 2);
+        }
+
+        let x = x.clone();
+        assert_eq!(x.len(), 10);
+        assert!(x.is_heap_allocated());
+        assert_eq!(x.get(&9), Some(&18));
+    }
+
+    #[test]
+    fn inlinehashmap() {
+        let mut x = InlineHashMap::<&'static str, usize, 4>::new();
+        assert_eq!(x.len(), 0);
+        assert_eq!(x.get(&"hi"), None);
+        assert!(!x.is_heap_allocated());
+
+        x.insert("foo", 1337);
+        assert_eq!(x.len(), 1);
+        assert_eq!(x.get(&"foo"), Some(&1337));
+        assert!(!x.is_heap_allocated());
+
+        x.insert("foo2", 2);
+        x.insert("foo3", 3);
+        x.insert("foo4", 4);
+
+        assert_eq!(x.len(), 4);
+
+        x.insert("foo5", 5);
+        assert_eq!(x.len(), 5);
+        assert!(x.is_heap_allocated());
+
+        x.insert("foo6", 6);
+        x.insert("foo7", 7);
+        x.insert("foo8", 8);
+        x.insert("foo9", 9);
+        x.insert("foo10", 10);
+        x.insert("foo11", 11);
+    }
+}

--- a/src/inline/mod.rs
+++ b/src/inline/mod.rs
@@ -1,0 +1,9 @@
+use std::mem::MaybeUninit;
+
+pub mod hashmap;
+pub mod vec;
+
+fn uninit_array<T, const N: usize>() -> [MaybeUninit<T>; N] {
+    // SAFETY: an array of MaybeUninits is allowed to be entirely uninit
+    unsafe { MaybeUninit::uninit().assume_init() }
+}

--- a/src/inline/mod.rs
+++ b/src/inline/mod.rs
@@ -1,6 +1,8 @@
 use std::mem::MaybeUninit;
 
+/// Inline HashMap
 pub mod hashmap;
+/// Inline vector
 pub mod vec;
 
 fn uninit_array<T, const N: usize>() -> [MaybeUninit<T>; N] {

--- a/src/inline/vec.rs
+++ b/src/inline/vec.rs
@@ -1,0 +1,241 @@
+use std::fmt::{Debug, Formatter};
+use std::mem::MaybeUninit;
+use std::ops::Index;
+
+/// A wrapper around a `Vec<T>` that lives on the stack
+/// if it is small enough
+///
+/// To convert to a `Vec<T>` use `Vec::from`
+pub enum InlineVec<T, const N: usize> {
+    /// Inline array
+    Inline {
+        /// Length of the array
+        len: usize,
+        /// Data stored in the array
+        data: [MaybeUninit<T>; N],
+    },
+    /// Heap allocated Vec
+    Heap(Vec<T>),
+}
+
+impl<T, const N: usize> Debug for InlineVec<T, N>
+where
+    T: Debug,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "InlineVec<{} items>", self.len())
+    }
+}
+
+impl<T, const N: usize> Clone for InlineVec<T, N>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        match self {
+            Self::Heap(m) => Self::Heap(m.clone()),
+            Self::Inline { len, data } => {
+                let mut new_data = super::uninit_array();
+
+                let iter = data.iter().take(*len).enumerate();
+
+                for (idx, element) in iter {
+                    let element = unsafe { &*element.as_ptr() };
+                    new_data[idx] = MaybeUninit::new(T::clone(element));
+                }
+
+                Self::Inline {
+                    len: *len,
+                    data: new_data,
+                }
+            }
+        }
+    }
+}
+
+impl<T, const N: usize> From<InlineVec<T, N>> for Vec<T> {
+    fn from(vec: InlineVec<T, N>) -> Self {
+        match vec {
+            InlineVec::Heap(m) => m,
+            InlineVec::Inline { len, data } => {
+                let mut new_data = Vec::with_capacity(len);
+
+                let iter = data.into_iter().take(len);
+
+                for element in iter {
+                    new_data.push(unsafe { element.assume_init() });
+                }
+
+                new_data
+            }
+        }
+    }
+}
+
+impl<T, const N: usize> InlineVec<T, N> {
+    /// Creates a new InlineVec
+    #[inline]
+    pub fn new() -> Self {
+        Self::Inline {
+            len: 0,
+            data: super::uninit_array(),
+        }
+    }
+
+    /// Returns a slice to the contents of this vector
+    pub fn as_slice(&self) -> &[T] {
+        match self {
+            Self::Heap(v) => v.as_slice(),
+            Self::Inline { len, data } => unsafe {
+                std::slice::from_raw_parts(data.as_ptr() as *const T, *len)
+            },
+        }
+    }
+
+    /// Returns an iterator over the elements of the vector
+    pub fn iter(&self) -> InlineVecIter<'_, T, N> {
+        InlineVecIter { idx: 0, vec: self }
+    }
+
+    /// Returns the length of this vector
+    #[inline]
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Inline { len, .. } => *len,
+            Self::Heap(vec) => vec.len(),
+        }
+    }
+
+    /// Returns the element at a given index
+    pub fn get(&self, idx: usize) -> Option<&T> {
+        match self {
+            Self::Inline { data, len } => {
+                if idx < *len {
+                    Some(unsafe { &*data.get_unchecked(idx).as_ptr() })
+                } else {
+                    None
+                }
+            }
+            Self::Heap(vec) => vec.get(idx),
+        }
+    }
+
+    /// Pushes a new element to the end of this vector
+    pub fn push(&mut self, value: T) -> usize {
+        let (array, len) = match self {
+            Self::Inline { data, len } => (data, len),
+            Self::Heap(vec) => {
+                vec.push(value);
+                return vec.len() - 1;
+            }
+        };
+
+        if *len >= N {
+            let mut vec = Vec::with_capacity(*len);
+
+            // move old elements to heap
+            for element in array.iter_mut().take(*len) {
+                let element = std::mem::replace(element, MaybeUninit::uninit());
+
+                vec.push(unsafe { element.assume_init() });
+            }
+
+            // push the new element
+            vec.push(value);
+            let len = vec.len() - 1;
+
+            *self = InlineVec::Heap(vec);
+
+            len - 1
+        } else {
+            array[*len].write(value);
+            *len += 1;
+            *len - 1
+        }
+    }
+
+    /// Checks whether this vector is allocated on the heap
+    #[inline]
+    pub fn is_heap_allocated(&self) -> bool {
+        matches!(self, Self::Heap(_))
+    }
+}
+
+impl<T, const N: usize> Index<usize> for InlineVec<T, N> {
+    type Output = T;
+
+    fn index(&self, idx: usize) -> &Self::Output {
+        self.get(idx).expect("index out of bounds")
+    }
+}
+
+/// An iterator over the elements stored in an [`InlineVec`]
+pub struct InlineVecIter<'a, T, const N: usize> {
+    vec: &'a InlineVec<T, N>,
+    idx: usize,
+}
+
+impl<'a, T, const N: usize> Iterator for InlineVecIter<'a, T, N> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.idx += 1;
+        self.vec.get(self.idx - 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inlinevec_iter() {
+        let mut x = InlineVec::<usize, 2>::new();
+        x.push(13);
+        x.push(42);
+        x.push(17);
+        x.push(19);
+        let mut iter = x.iter();
+        assert_eq!(iter.next(), Some(&13));
+        assert_eq!(iter.next(), Some(&42));
+        assert_eq!(iter.next(), Some(&17));
+        assert_eq!(iter.next(), Some(&19));
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn inlinevec() {
+        let mut x = InlineVec::<usize, 4>::new();
+        assert_eq!(x.len(), 0);
+        assert_eq!(x.get(0), None);
+        assert!(!x.is_heap_allocated());
+
+        x.push(1337);
+        assert_eq!(x.len(), 1);
+        assert_eq!(x.get(0), Some(&1337));
+        assert!(!x.is_heap_allocated());
+
+        for v in 0..3 {
+            x.push(v);
+        }
+
+        assert_eq!(x.len(), 4);
+
+        // this call should move the vector to the heap
+        x.push(42);
+        assert_eq!(x.len(), 5);
+        assert!(x.is_heap_allocated());
+
+        // check that the old vector is still valid
+        assert_eq!(x.get(0), Some(&1337));
+
+        for v in 0..500 {
+            x.push(v);
+        }
+
+        assert_eq!(x.len(), 505);
+        assert!(x.is_heap_allocated());
+
+        assert_eq!(x.get(1337), None);
+    }
+}

--- a/src/inline/vec.rs
+++ b/src/inline/vec.rs
@@ -269,4 +269,16 @@ mod tests {
 
         assert_eq!(x.get(1337), None);
     }
+
+    #[test]
+    fn inlinevec_as_slice() {
+        let mut x = InlineVecInner::<usize, 4>::new();
+        x.push(1337);
+        x.push(42);
+        x.push(17);
+        assert_eq!(x.as_slice(), &[1337, 42, 17]);
+        x.push(19);
+        x.push(34);
+        assert_eq!(x.as_slice(), &[1337, 42, 17, 19, 34]);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,45 +1,8 @@
-//! tl is an efficient and easy to use HTML parser written in Rust.
-//!
-//! It does minimal to no copying during parsing by borrowing parts of the input string.
-//! Additionally, it keeps track of parsed elements and stores elements with an id attribute
-//! in an internal HashMap, which makes element lookups by ID/class name very fast.
-//!
-//! ## Examples
-//! Finding an element by its id attribute and printing the inner text:
-//! ```rust
-//! let input = r#"<p id="text">Hello</p>"#;
-//! let dom = tl::parse(input);
-//!
-//! let element = dom.get_element_by_id("text").expect("Failed to find element");
-//!
-//! println!("Inner text: {}", element.inner_text());
-//! ```
-//!
-//! ## Owned DOM
-//! Calling `tl::parse()` returns a DOM struct that borrows from the input string, which means that the string must be kept alive.
-//! The input string must outlive this DOM. If this is not acceptable or you need to keep the DOM around for longer,
-//! consider using `tl::parse_owned()`.
-//! `VDomGuard` takes ownership over the string, which means you don't have to keep the string around.
-//! ```rust
-//! // Notice how it takes ownership over the string:
-//! let dom_guard = unsafe { tl::parse_owned(String::from(r#"<p id="text">Hello</p>"#)) };
-//!
-//! // Obtain reference to underlying VDom
-//! let dom = dom_guard.get_ref();
-//!
-//! // Now, use `dom` as you would if it was a regular `VDom`
-//! let element = dom.get_element_by_id("text").expect("Failed to find element");
-//!
-//! println!("Inner text: {}", element.inner_text());
-//! ```
-//!
-//! ## Bytes
-//! Some methods return a `Bytes` struct, which is an internal struct that is used to borrow
-//! a part of the input string. This is mainly used over a raw `&[u8]` for its `Debug` implementation.
-
+#![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
 
 mod bytes;
+mod inline;
 mod parser;
 mod stream;
 #[cfg(test)]
@@ -48,8 +11,12 @@ mod util;
 mod vdom;
 
 pub use bytes::{AsBytes, Bytes};
-use parser::Parser;
-pub use parser::{tag::Attributes, tag::HTMLTag, tag::Node, HTMLVersion, Tree};
+pub use inline::{
+    hashmap::{InlineHashMap, InlineHashMapIterator},
+    vec::{InlineVec, InlineVecIter},
+};
+pub use parser::Parser;
+pub use parser::{handle::NodeHandle, tag::Attributes, tag::HTMLTag, tag::Node, HTMLVersion, Tree};
 pub use vdom::{VDom, VDomGuard};
 
 /// Parses the given input string

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@ pub use vdom::{VDom, VDomGuard};
 /// The input string must be kept alive, and must outlive `VDom`.
 /// If you need an "owned" version that takes an input string and can be kept around forever,
 /// consider using `parse_owned()`.
-pub fn parse(input: &str) -> VDom<'_> {
-    VDom::from(Parser::new(input).parse())
+pub fn parse(input: &str, options: ParserOptions) -> VDom<'_> {
+    VDom::from(Parser::new(input, options).parse())
 }
 
 /// Parses the given input string and returns an owned, RAII guarded DOM
@@ -32,6 +32,6 @@ pub fn parse(input: &str) -> VDom<'_> {
 /// The given input string is first leaked and turned into raw pointer, and its lifetime will be promoted to 'static.
 /// Once `VDomGuard` goes out of scope, the string will be freed.
 /// It should not be possible to cause UB in its current form and might become a safe function in the future.
-pub unsafe fn parse_owned<'a>(input: String) -> VDomGuard<'a> {
-    VDomGuard::parse(input)
+pub unsafe fn parse_owned<'a>(input: String, options: ParserOptions) -> VDomGuard<'a> {
+    VDomGuard::parse(input, options)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@
 #![deny(missing_docs)]
 
 mod bytes;
-mod inline;
+/// Inline data structures
+pub mod inline;
 mod parser;
 mod stream;
 #[cfg(test)]
@@ -11,12 +12,7 @@ mod util;
 mod vdom;
 
 pub use bytes::{AsBytes, Bytes};
-pub use inline::{
-    hashmap::{InlineHashMap, InlineHashMapIterator},
-    vec::{InlineVec, InlineVecIter},
-};
-pub use parser::Parser;
-pub use parser::{handle::NodeHandle, tag::Attributes, tag::HTMLTag, tag::Node, HTMLVersion, Tree};
+pub use parser::*;
 pub use vdom::{VDom, VDomGuard};
 
 /// Parses the given input string

--- a/src/parser/base.rs
+++ b/src/parser/base.rs
@@ -160,15 +160,11 @@ impl<'a> Parser<'a> {
                 } else if k.eq(constants::CLASS_ATTR) {
                     attributes.class = v.clone();
                 }
-                
-                if v.is_some() {
-                    self.stream.advance();
-                }
 
                 attributes.raw.insert(k.into(), v);
-
             }
 
+            self.stream.advance();
         }
 
         attributes

--- a/src/parser/base.rs
+++ b/src/parser/base.rs
@@ -160,11 +160,15 @@ impl<'a> Parser<'a> {
                 } else if k.eq(constants::CLASS_ATTR) {
                     attributes.class = v.clone();
                 }
+                
+                if v.is_some() {
+                    self.stream.advance();
+                }
 
                 attributes.raw.insert(k.into(), v);
+
             }
 
-            self.stream.advance();
         }
 
         attributes

--- a/src/parser/handle.rs
+++ b/src/parser/handle.rs
@@ -1,0 +1,31 @@
+use crate::Node;
+
+use super::Parser;
+
+/// An external handle to a HTML node, originally obtained from a [Parser]
+///
+/// It contains an identifier that uniquely identifies an HTML node.
+/// In particular, it is an index into the global HTML tag table managed by the [`Parser`].
+/// To get a [`Node`] out of a [`NodeHandle`], call `NodeHandle::get()`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct NodeHandle(usize);
+
+impl NodeHandle {
+    /// Creates a new handle to the given node
+    #[inline]
+    pub(crate) fn new(node: usize) -> Self {
+        NodeHandle(node)
+    }
+
+    /// Returns the node that is associated to this specific handle
+    pub fn get<'p, 'buf>(&self, parser: &'p Parser<'buf>) -> Option<&'p Node<'buf>> {
+        parser.resolve_node_id(self.0)
+    }
+
+    /// Returns the internal unique Node ID that maps to a specific node in the node table
+    #[inline]
+    pub(crate) fn get_inner(&self) -> usize {
+        self.0
+    }
+}

--- a/src/parser/handle.rs
+++ b/src/parser/handle.rs
@@ -14,7 +14,7 @@ pub struct NodeHandle(usize);
 impl NodeHandle {
     /// Creates a new handle to the given node
     #[inline]
-    pub(crate) fn new(node: usize) -> Self {
+    pub fn new(node: usize) -> Self {
         NodeHandle(node)
     }
 
@@ -25,7 +25,7 @@ impl NodeHandle {
 
     /// Returns the internal unique Node ID that maps to a specific node in the node table
     #[inline]
-    pub(crate) fn get_inner(&self) -> usize {
+    pub fn get_inner(&self) -> usize {
         self.0
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,6 +1,8 @@
-pub mod base;
-pub mod constants;
-pub mod handle;
-pub mod tag;
+mod base;
+mod constants;
+mod handle;
+mod tag;
 
 pub use base::*;
+pub use handle::*;
+pub use tag::*;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,5 +1,6 @@
 pub mod base;
 pub mod constants;
+pub mod handle;
 pub mod tag;
 
 pub use base::*;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,8 +1,10 @@
 mod base;
 mod constants;
 mod handle;
+mod options;
 mod tag;
 
 pub use base::*;
 pub use handle::*;
+pub use options::*;
 pub use tag::*;

--- a/src/parser/options.rs
+++ b/src/parser/options.rs
@@ -1,6 +1,7 @@
 mod flags {
-    pub const TRACK_IDS: u8 = 1;
-    pub const TRACK_CLASSES: u8 = 2;
+    pub const TRACK_IDS: u8 = 1 << 0;
+    pub const TRACK_CLASSES: u8 = 1 << 1;
+    pub const HIGHEST: u8 = TRACK_CLASSES;
 }
 
 /// Options for the HTML Parser
@@ -19,9 +20,23 @@ impl Default for ParserOptions {
 }
 
 impl ParserOptions {
-    /// Creates a new ParserOptions with no flags set
+    /// Creates a new [ParserOptions] with no flags set
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Creates a [ParserOptions] from a bitset
+    pub fn from_raw_checked(flags: u8) -> Option<Self> {
+        if flags > flags::HIGHEST * 2 - 1 {
+            None
+        } else {
+            Some(Self(flags))
+        }
+    }
+
+    /// Returns the raw flags of this bitset
+    pub fn to_raw(&self) -> u8 {
+        self.0
     }
 
     fn set_flag(&mut self, flag: u8) {

--- a/src/parser/options.rs
+++ b/src/parser/options.rs
@@ -1,0 +1,72 @@
+mod flags {
+    pub const TRACK_IDS: u8 = 1;
+    pub const TRACK_CLASSES: u8 = 2;
+}
+
+/// Options for the HTML Parser
+///
+/// This allows users of this library to configure the parser.
+/// The default options (`ParserOptions::default()`) are optimized for raw parsing.
+/// If you need to do HTML tag lookups by ID or class names, you can enable tracking.
+/// This will cache HTML nodes as they appear in the source code on the fly.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct ParserOptions(u8);
+
+impl Default for ParserOptions {
+    fn default() -> Self {
+        Self(0)
+    }
+}
+
+impl ParserOptions {
+    /// Creates a new ParserOptions with no flags set
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn set_flag(&mut self, flag: u8) {
+        self.0 |= flag;
+    }
+
+    #[inline]
+    fn has_flag(&self, flag: u8) -> bool {
+        self.0 & flag != 0
+    }
+
+    /// Enables tracking of HTML Tag IDs and stores them in a lookup table.
+    ///
+    /// This makes `get_element_by_id()` lookups ~O(1)
+    pub fn track_ids(mut self) -> Self {
+        self.set_flag(flags::TRACK_IDS);
+        self
+    }
+
+    /// Enables tracking of HTML Tag classes and stores them in a lookup table.
+    ///
+    /// This makes `get_elements_by_class_name()` lookups ~O(1)
+    pub fn track_classes(mut self) -> Self {
+        self.set_flag(flags::TRACK_CLASSES);
+        self
+    }
+
+    /// Returns whether the parser is tracking HTML Tag IDs.
+    #[inline]
+    pub fn is_tracking_ids(&self) -> bool {
+        self.has_flag(flags::TRACK_IDS)
+    }
+
+    /// Returns whether the parser is tracking HTML Tag classes.
+    #[inline]
+    pub fn is_tracking_classes(&self) -> bool {
+        self.has_flag(flags::TRACK_CLASSES)
+    }
+
+    /// Returns whether the parser is tracking HTML Tag IDs or classes (previously enabled by a call to `track_ids()` or `track_classes()`).
+    #[inline]
+    pub fn is_tracking(&self) -> bool {
+        // for now we can just check if any bit is set, may or may not lead to better codegen than two cmps
+        // this must be changed in some way if we ever add more flags
+        // self.is_tracking_ids() || self.is_tracking_classes()
+        self.0 > 0
+    }
+}

--- a/src/parser/tag.rs
+++ b/src/parser/tag.rs
@@ -12,7 +12,6 @@ const INLINE_LENGTH: usize = 4;
 #[derive(Debug, Clone)]
 pub struct Attributes<'a> {
     /// Raw attributes (maps attribute key to attribute value)
-    // pub raw: HashMap<Bytes<'a>, Option<Bytes<'a>>>,
     pub raw: InlineHashMap<Bytes<'a>, Option<Bytes<'a>>, INLINE_LENGTH>,
     /// The ID of this HTML element, if present
     pub id: Option<Bytes<'a>>,
@@ -34,7 +33,7 @@ impl<'a> Attributes<'a> {
 /// Represents a single HTML element
 #[derive(Debug, Clone)]
 pub struct HTMLTag<'a> {
-    pub(crate) _name: Option<Bytes<'a>>,
+    pub(crate) _name: Bytes<'a>,
     pub(crate) _attributes: Attributes<'a>,
     pub(crate) _children: InlineVec<NodeHandle, INLINE_LENGTH>,
     pub(crate) _raw: Bytes<'a>,
@@ -44,7 +43,7 @@ impl<'a> HTMLTag<'a> {
     /// Creates a new HTMLTag
     #[inline]
     pub(crate) fn new(
-        name: Option<Bytes<'a>>,
+        name: Bytes<'a>,
         attr: Attributes<'a>,
         children: InlineVec<NodeHandle, INLINE_LENGTH>,
         raw: Bytes<'a>,
@@ -63,7 +62,7 @@ impl<'a> HTMLTag<'a> {
     }
 
     /// Returns the name of this HTML tag
-    pub fn name(&self) -> &Option<Bytes<'a>> {
+    pub fn name(&self) -> &Bytes<'a> {
         &self._name
     }
 

--- a/src/parser/tag.rs
+++ b/src/parser/tag.rs
@@ -1,11 +1,19 @@
-use crate::Bytes;
-use std::{borrow::Cow, collections::HashMap, rc::Rc};
+use crate::{
+    inline::{hashmap::InlineHashMap, vec::InlineVec},
+    Bytes,
+};
+use std::borrow::Cow;
+
+use super::{handle::NodeHandle, Parser};
+
+const INLINE_LENGTH: usize = 4;
 
 /// Stores all attributes of an HTML tag, as well as additional metadata such as `id` and `class`
 #[derive(Debug, Clone)]
 pub struct Attributes<'a> {
     /// Raw attributes (maps attribute key to attribute value)
-    pub raw: HashMap<Bytes<'a>, Option<Bytes<'a>>>,
+    // pub raw: HashMap<Bytes<'a>, Option<Bytes<'a>>>,
+    pub raw: InlineHashMap<Bytes<'a>, Option<Bytes<'a>>, INLINE_LENGTH>,
     /// The ID of this HTML element, if present
     pub id: Option<Bytes<'a>>,
     /// A list of class names of this HTML element, if present
@@ -16,7 +24,7 @@ impl<'a> Attributes<'a> {
     /// Creates a new `Attributes
     pub(crate) fn new() -> Self {
         Self {
-            raw: HashMap::new(),
+            raw: InlineHashMap::new(),
             id: None,
             class: None,
         }
@@ -28,16 +36,17 @@ impl<'a> Attributes<'a> {
 pub struct HTMLTag<'a> {
     pub(crate) _name: Option<Bytes<'a>>,
     pub(crate) _attributes: Attributes<'a>,
-    pub(crate) _children: Vec<Rc<Node<'a>>>,
+    pub(crate) _children: InlineVec<NodeHandle, INLINE_LENGTH>,
     pub(crate) _raw: Bytes<'a>,
 }
 
 impl<'a> HTMLTag<'a> {
     /// Creates a new HTMLTag
+    #[inline]
     pub(crate) fn new(
         name: Option<Bytes<'a>>,
         attr: Attributes<'a>,
-        children: Vec<Rc<Node<'a>>>,
+        children: InlineVec<NodeHandle, INLINE_LENGTH>,
         raw: Bytes<'a>,
     ) -> Self {
         Self {
@@ -48,9 +57,9 @@ impl<'a> HTMLTag<'a> {
         }
     }
 
-    /// Returns a vector of subnodes ("children") of this HTML tag
-    pub fn children(&self) -> &Vec<Rc<Node<'a>>> {
-        &self._children
+    /// Returns an iterator over subnodes ("children") of this HTML tag
+    pub fn children(&self) -> impl Iterator<Item = NodeHandle> + '_ {
+        self._children.iter().copied()
     }
 
     /// Returns the name of this HTML tag
@@ -73,7 +82,7 @@ impl<'a> HTMLTag<'a> {
     /// Equivalent to [Element#innerText](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerText) in browsers)
     /// This function may not allocate memory for a new string as it can just return the part of the tag that doesn't have markup
     /// For tags that *do* have more than one subnode, this will allocate memory
-    pub fn inner_text(&self) -> Cow<'a, str> {
+    pub fn inner_text(&self, parser: &Parser<'a>) -> Cow<'a, str> {
         let len = self._children.len();
 
         if len == 0 {
@@ -81,11 +90,11 @@ impl<'a> HTMLTag<'a> {
             return Cow::Borrowed("");
         }
 
-        let first = &self._children[0];
+        let first = self._children[0].get(parser).unwrap();
 
         if len == 1 {
-            match &**first {
-                Node::Tag(t) => return t.inner_text(),
+            match &first {
+                Node::Tag(t) => return t.inner_text(parser),
                 Node::Raw(e) => return e.as_utf8_str(),
                 Node::Comment(_) => return Cow::Borrowed(""),
             }
@@ -93,11 +102,13 @@ impl<'a> HTMLTag<'a> {
 
         // If there are >1 nodes, we need to allocate a new string and push each inner_text in it
         // TODO: check if String::with_capacity() is worth it
-        let mut s = String::from(first.inner_text());
+        let mut s = String::from(first.inner_text(parser));
 
-        for node in self._children.iter().skip(1) {
-            match &**node {
-                Node::Tag(t) => s.push_str(&t.inner_text()),
+        for &id in self._children.iter().skip(1) {
+            let node = id.get(parser).unwrap();
+
+            match &node {
+                Node::Tag(t) => s.push_str(&t.inner_text(parser)),
                 Node::Raw(e) => s.push_str(&e.as_utf8_str()),
                 Node::Comment(_) => { /* no op */ }
             }
@@ -110,16 +121,17 @@ impl<'a> HTMLTag<'a> {
     ///
     /// The closure must return a boolean, indicating whether it should stop iterating
     /// Returning `true` will break the loop
-    pub fn find_node<'b, F>(&'b self, f: &mut F) -> Option<&'b Rc<Node<'a>>>
+    pub fn find_node<F>(&self, parser: &Parser<'a>, f: &mut F) -> Option<NodeHandle>
     where
-        F: FnMut(&Rc<Node<'a>>) -> bool,
+        F: FnMut(&Node<'a>) -> bool,
     {
-        for node in self.children() {
-            if let Some(tag) = node.find_node(f) {
-                return Some(tag);
+        for &id in self._children.iter() {
+            let node = id.get(parser).unwrap();
+
+            if f(node) {
+                return Some(id);
             }
         }
-
         None
     }
 }
@@ -137,32 +149,44 @@ pub enum Node<'a> {
 
 impl<'a> Node<'a> {
     /// Returns the inner text of this node
-    pub fn inner_text(&self) -> Cow<'a, str> {
+    pub fn inner_text(&self, parser: &Parser<'a>) -> Cow<'a, str> {
         match self {
             Node::Comment(_) => Cow::Borrowed(""),
             Node::Raw(r) => r.as_utf8_str(),
-            Node::Tag(t) => t.inner_text(),
+            Node::Tag(t) => t.inner_text(parser),
+        }
+    }
+
+    /// Returns an iterator over subnodes ("children") of this HTML tag, if this is a tag
+    pub fn children(&self) -> Option<impl Iterator<Item = NodeHandle> + '_> {
+        match self {
+            Node::Tag(t) => Some(t.children()),
+            _ => None,
         }
     }
 
     /// Calls the given closure with each tag as parameter
     ///
     /// The closure must return a boolean, indicating whether it should stop iterating
-    /// Returning `true` will break the loop
-    pub fn find_node<'b, F>(self: &'b Rc<Node<'a>>, f: &mut F) -> Option<&'b Rc<Node<'a>>>
+    /// Returning `true` will break the loop and return a handle to the node
+    pub fn find_node<F>(&self, parser: &Parser<'a>, f: &mut F) -> Option<NodeHandle>
     where
-        F: FnMut(&Rc<Node<'a>>) -> bool,
+        F: FnMut(&Node<'a>) -> bool,
     {
-        if f(self) {
-            return Some(self);
-        }
+        if let Some(children) = self.children() {
+            for id in children {
+                let node = id.get(parser).unwrap();
 
-        if let Self::Tag(tag) = &**self {
-            if let Some(tag) = tag.find_node(f) {
-                return Some(tag);
+                if f(node) {
+                    return Some(id);
+                }
+
+                let subnode = node.find_node(parser, f);
+                if subnode.is_some() {
+                    return subnode;
+                }
             }
         }
-
         None
     }
 

--- a/src/parser/tag.rs
+++ b/src/parser/tag.rs
@@ -41,6 +41,13 @@ impl<'a> Attributes<'a> {
         }
         raw
     }
+
+    /// Checks whether a given string is in the class names list
+    pub fn is_class_member(&self, member: &str) -> bool {
+        self.class.as_ref().map_or(false, |b| {
+            b.as_utf8_str().split_whitespace().any(|x| x == member)
+        })
+    }
 }
 
 /// Represents a single HTML element

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -42,9 +42,7 @@ impl<'a, T: Eq + Copy> Stream<'a, T> {
 
     /// Same as expect_and_skip, but returns a bool
     pub fn expect_and_skip_cond(&mut self, expect: T) -> bool {
-        self.expect_and_skip(expect)
-            .map(|c| c == expect)
-            .unwrap_or(false)
+        self.expect_and_skip(expect).map_or(false, |c| c == expect)
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -9,16 +9,8 @@ pub struct Stream<'a, T> {
 
 impl<'a, T: Copy> Stream<'a, T> {
     /// Returns a copy of the current element
+    #[inline]
     pub fn current_cpy(&self) -> Option<T> {
-        self.data.get(self.idx).copied()
-    }
-    /// Returns a copy of the current element, and panicks if it's out of bounds
-    pub fn current_unchecked_cpy(&self) -> T {
-        self.data[self.idx]
-    }
-    /// Returns a copy of the next element
-    pub fn next_cpy(&mut self) -> Option<T> {
-        self.advance();
         self.data.get(self.idx).copied()
     }
 }
@@ -47,21 +39,12 @@ impl<'a, T: Eq + Copy> Stream<'a, T> {
             .map(|c| c == expect)
             .unwrap_or(false)
     }
-
-    pub fn is_next(&self, expect: T) -> bool {
-        self.peek().map(|x| *x == expect).unwrap_or(false)
-    }
 }
 
 impl<'a, T> Stream<'a, T> {
     /// Creates a new stream
     pub fn new(data: &'a [T]) -> Stream<T> {
         Self { data, idx: 0 }
-    }
-
-    /// Returns the current element
-    pub fn current(&self) -> Option<&T> {
-        self.data.get(self.idx)
     }
 
     /// Returns the next element
@@ -72,51 +55,49 @@ impl<'a, T> Stream<'a, T> {
         })
     }
 
-    pub fn peek(&self) -> Option<&T> {
-        self.data.get(self.idx + 1)
-    }
-
+    #[inline]
     pub fn advance(&mut self) {
         self.idx += 1;
     }
 
+    #[inline]
     pub fn advance_by(&mut self, step: usize) {
         self.idx += step;
     }
 
     /// Returns the current element, but panicks if out of bounds
+    #[inline]
     pub fn current_unchecked(&self) -> &T {
         &self.data[self.idx]
     }
 
-    /// Returns the current element without any boundary checks
-    /// This *will* cause UB if the current index is out of bounds
-    pub unsafe fn current_unchecked_fast(&self) -> &T {
-        &*self.data.as_ptr().add(self.idx)
-    }
-
     /// Checks whether the stream has reached the end
+    #[inline]
     pub fn is_eof(&self) -> bool {
         self.idx >= self.data.len()
     }
 
     /// Returns a subslice of this stream, and panicks if out of bounds
+    #[inline]
     pub fn slice_unchecked(&self, from: usize, to: usize) -> &'a [T] {
         &self.data[from..to]
     }
 
     /// Returns a subslice of this stream but also checks stream length
     /// to prevent out of bounds panicking
+    #[inline]
     pub fn slice(&self, from: usize, to: usize) -> &'a [T] {
         &self.data[from..min(self.data.len(), to)]
     }
 
     /// Same as slice, but the second argument is how many elements to slice
+    #[inline]
     pub fn slice_len(&self, from: usize, len: usize) -> &'a [T] {
         self.slice(from, self.idx + len)
     }
 
     /// Same as slice, but uses the current index + 1 as `to`
+    #[inline]
     pub fn slice_from(&self, from: usize) -> &'a [T] {
         self.slice(from, self.idx)
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -97,14 +97,32 @@ fn with() {
     let dom = parse(input);
     let parser = dom.parser();
 
-    let tag = dom.find_node(|node| {
-        node.as_tag()
-            .map(|tag| tag.name() == &Some("span".into()))
-            .unwrap_or(false)
-    });
+    let tag = dom
+        .nodes()
+        .iter()
+        .find(|x| x.as_tag().map_or(false, |x| x.name() == &"span".into()));
 
     assert_eq!(
-        tag.map(|tag| tag.get(parser).unwrap().inner_text(parser)),
+        tag.map(|tag| tag.inner_text(parser)),
         Some("whats up".into())
     )
+}
+
+#[test]
+fn abrupt_attributes_stop() {
+    let input = r#"<p "#;
+    parse(input);
+}
+
+#[test]
+fn dom_nodes() {
+    let input = r#"<p><p><a>nested</a></p></p>"#;
+    let dom = parse(input);
+    let parser = dom.parser();
+    let element = dom
+        .nodes()
+        .iter()
+        .find(|x| x.as_tag().map_or(false, |x| x.name().eq(&"a".into())));
+
+    assert_eq!(element.map(|x| x.inner_text(parser)), Some("nested".into()));
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10,7 +10,7 @@ fn force_as_tag<'a, 'b>(actual: &'a Node<'b>) -> &'a HTMLTag<'b> {
 
 #[test]
 fn inner_html() {
-    let dom = parse("abc <p>test</p> def");
+    let dom = parse("abc <p>test</p> def", ParserOptions::default());
     let parser = dom.parser();
 
     let tag = force_as_tag(dom.children()[1].get(parser).unwrap());
@@ -20,13 +20,19 @@ fn inner_html() {
 
 #[test]
 fn children_len() {
-    let dom = parse("<!-- element 1 --> <div><div>element 3</div></div>");
+    let dom = parse(
+        "<!-- element 1 --> <div><div>element 3</div></div>",
+        ParserOptions::default(),
+    );
     assert_eq!(dom.children().len(), 2);
 }
 
 #[test]
-fn get_element_by_id() {
-    let dom = parse("<div></div><p id=\"test\"></p><p></p>");
+fn get_element_by_id_default() {
+    let dom = parse(
+        "<div></div><p id=\"test\"></p><p></p>",
+        ParserOptions::default(),
+    );
 
     let tag = dom.get_element_by_id("test").expect("Element not present");
 
@@ -36,8 +42,50 @@ fn get_element_by_id() {
 }
 
 #[test]
+fn get_element_by_id_tracking() {
+    let dom = parse(
+        "<div></div><p id=\"test\"></p><p></p>",
+        ParserOptions::default().track_ids(),
+    );
+
+    let tag = dom.get_element_by_id("test").expect("Element not present");
+
+    let el = force_as_tag(tag.get(dom.parser()).unwrap());
+
+    assert_eq!(el.inner_html().as_utf8_str(), "<p id=\"test\"></p>")
+}
+
+#[test]
+fn get_element_by_class_name_default() {
+    let dom = parse(
+        "<div></div><p class=\"a b\">hey</p><p></p>",
+        ParserOptions::default(),
+    );
+
+    let tag = dom.get_elements_by_class_name("a").next().unwrap();
+
+    let el = force_as_tag(tag.get(dom.parser()).unwrap());
+
+    assert_eq!(el.inner_text(dom.parser()), "hey");
+}
+
+#[test]
+fn get_element_by_class_name_tracking() {
+    let dom = parse(
+        "<div></div><p class=\"a b\">hey</p><p></p>",
+        ParserOptions::default().track_ids(),
+    );
+
+    let tag = dom.get_elements_by_class_name("a").next().unwrap();
+
+    let el = force_as_tag(tag.get(dom.parser()).unwrap());
+
+    assert_eq!(el.inner_text(dom.parser()), "hey");
+}
+
+#[test]
 fn html5() {
-    let dom = parse("<!DOCTYPE html> hello");
+    let dom = parse("<!DOCTYPE html> hello", ParserOptions::default());
 
     assert_eq!(dom.version(), Some(HTMLVersion::HTML5));
     assert_eq!(dom.children().len(), 1)
@@ -45,7 +93,10 @@ fn html5() {
 
 #[test]
 fn nested_inner_text() {
-    let dom = parse("<p>hello <p>nested element</p></p>");
+    let dom = parse(
+        "<p>hello <p>nested element</p></p>",
+        ParserOptions::default(),
+    );
     let parser = dom.parser();
 
     let el = force_as_tag(dom.children()[0].get(parser).unwrap());
@@ -57,7 +108,7 @@ fn nested_inner_text() {
 fn owned_dom() {
     let owned_dom = {
         let input = String::from("<p id=\"test\">hello</p>");
-        let dom = unsafe { parse_owned(input) };
+        let dom = unsafe { parse_owned(input, ParserOptions::default()) };
         dom
     };
 
@@ -73,7 +124,7 @@ fn owned_dom() {
 fn move_owned() {
     let input = String::from("<p id=\"test\">hello</p>");
 
-    let guard = unsafe { parse_owned(input) };
+    let guard = unsafe { parse_owned(input, ParserOptions::default()) };
 
     fn move_me<T>(p: T) -> T {
         p
@@ -94,7 +145,7 @@ fn move_owned() {
 fn with() {
     let input = r#"<p>hello <span>whats up</span></p>"#;
 
-    let dom = parse(input);
+    let dom = parse(input, ParserOptions::default());
     let parser = dom.parser();
 
     let tag = dom
@@ -111,13 +162,13 @@ fn with() {
 #[test]
 fn abrupt_attributes_stop() {
     let input = r#"<p "#;
-    parse(input);
+    parse(input, ParserOptions::default());
 }
 
 #[test]
 fn dom_nodes() {
     let input = r#"<p><p><a>nested</a></p></p>"#;
-    let dom = parse(input);
+    let dom = parse(input, ParserOptions::default());
     let parser = dom.parser();
     let element = dom
         .nodes()

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -11,8 +11,9 @@ fn force_as_tag<'a, 'b>(actual: &'a Node<'b>) -> &'a HTMLTag<'b> {
 #[test]
 fn inner_html() {
     let dom = parse("abc <p>test</p> def");
+    let parser = dom.parser();
 
-    let tag = force_as_tag(&dom.children()[1]);
+    let tag = force_as_tag(dom.children()[1].get(parser).unwrap());
 
     assert_eq!(tag.inner_html().as_utf8_str(), "<p>test</p>");
 }
@@ -29,7 +30,7 @@ fn get_element_by_id() {
 
     let tag = dom.get_element_by_id("test").expect("Element not present");
 
-    let el = force_as_tag(&tag);
+    let el = force_as_tag(tag.get(dom.parser()).unwrap());
 
     assert_eq!(el.inner_html().as_utf8_str(), "<p id=\"test\"></p>")
 }
@@ -45,10 +46,11 @@ fn html5() {
 #[test]
 fn nested_inner_text() {
     let dom = parse("<p>hello <p>nested element</p></p>");
+    let parser = dom.parser();
 
-    let el = force_as_tag(&dom.children()[0]);
+    let el = force_as_tag(dom.children()[0].get(parser).unwrap());
 
-    assert_eq!(el.inner_text(), "hello nested element");
+    assert_eq!(el.inner_text(parser), "hello nested element");
 }
 
 #[test]
@@ -60,10 +62,11 @@ fn owned_dom() {
     };
 
     let dom = owned_dom.get_ref();
+    let parser = dom.parser();
 
-    let el = force_as_tag(&dom.children()[0]);
+    let el = force_as_tag(dom.children()[0].get(parser).unwrap());
 
-    assert_eq!(el.inner_text(), "hello");
+    assert_eq!(el.inner_text(parser), "hello");
 }
 
 #[test]
@@ -80,10 +83,11 @@ fn move_owned() {
     let guard = move_me(guard);
 
     let dom = guard.get_ref();
+    let parser = dom.parser();
 
-    let el = force_as_tag(&dom.children()[0]);
+    let el = force_as_tag(dom.children()[0].get(parser).unwrap());
 
-    assert_eq!(el.inner_text(), "hello");
+    assert_eq!(el.inner_text(parser), "hello");
 }
 
 #[test]
@@ -91,6 +95,7 @@ fn with() {
     let input = r#"<p>hello <span>whats up</span></p>"#;
 
     let dom = parse(input);
+    let parser = dom.parser();
 
     let tag = dom.find_node(|node| {
         node.as_tag()
@@ -98,5 +103,8 @@ fn with() {
             .unwrap_or(false)
     });
 
-    assert_eq!(tag.map(|tag| tag.inner_text()), Some("whats up".into()))
+    assert_eq!(
+        tag.map(|tag| tag.get(parser).unwrap().inner_text(parser)),
+        Some("whats up".into())
+    )
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,6 +6,7 @@ pub fn is_ident(c: u8) -> bool {
         || c == b'_'
 }
 
+#[inline]
 pub fn is_strict_whitespace(c: u8) -> bool {
-    [b' '].contains(&c)
+    c == b' '
 }

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -1,8 +1,14 @@
+use crate::parser::handle::NodeHandle;
+use crate::parser::ClassVec;
 use crate::{bytes::AsBytes, parser::HTMLVersion};
-use crate::{Node, Parser, Tree};
-use std::{marker::PhantomData, rc::Rc};
+use crate::{Node, Parser};
+use std::marker::PhantomData;
 
 /// VDom represents a [Document Object Model](https://developer.mozilla.org/en/docs/Web/API/Document_Object_Model)
+///
+/// It is the result of parsing an HTML document.
+/// Internally it is only a wrapper around the [`Parser`] struct, but you do not need to know much about the [`Parser`] struct except for that all of the HTML tags are stored in here.
+/// Many functions of the public API take a reference to a [`Parser`] as a parameter to resolve [`NodeHandle`]s to [`Node`]s.
 #[derive(Debug)]
 pub struct VDom<'a> {
     /// Internal parser
@@ -16,19 +22,22 @@ impl<'a> From<Parser<'a>> for VDom<'a> {
 }
 
 impl<'a> VDom<'a> {
-    /// Finds an element by its `id` attribute. This operation is O(1), as it's only a HashMap lookup
-    pub fn get_element_by_id<'b, S: ?Sized>(&'b self, id: &'b S) -> Option<&'b Rc<Node<'a>>>
+    /// Returns a reference to the underlying parser
+    #[inline]
+    pub fn parser(&self) -> &Parser<'a> {
+        &self.parser
+    }
+
+    /// Finds an element by its `id` attribute.
+    pub fn get_element_by_id<'b, S: ?Sized>(&'b self, id: &'b S) -> Option<NodeHandle>
     where
         S: AsBytes,
     {
-        self.parser.ids.get(&id.as_bytes())
+        self.parser.ids.get(&id.as_bytes()).copied()
     }
 
-    /// Returns a list of elements that match a given class name. This operation is O(1), as it's only a HashMap lookup
-    pub fn get_elements_by_class_name<'b, S: ?Sized>(
-        &'b self,
-        id: &'b S,
-    ) -> Option<&'b Vec<Rc<Node<'a>>>>
+    /// Returns a list of elements that match a given class name.
+    pub fn get_elements_by_class_name<'b, S: ?Sized>(&'b self, id: &'b S) -> Option<&'b ClassVec>
     where
         S: AsBytes,
     {
@@ -36,7 +45,7 @@ impl<'a> VDom<'a> {
     }
 
     /// Returns all subnodes ("children") of this DOM
-    pub fn children(&self) -> &Tree<'a> {
+    pub fn children(&self) -> &[NodeHandle] {
         &self.parser.ast
     }
 
@@ -50,13 +59,17 @@ impl<'a> VDom<'a> {
     ///
     /// The closure must return a boolean, indicating whether it should stop iterating
     /// Returning `true` will break the loop
-    pub fn find_node<F>(&self, mut f: F) -> Option<&Rc<Node<'a>>>
+    pub fn find_node<F>(&self, mut f: F) -> Option<NodeHandle>
     where
-        F: FnMut(&Rc<Node<'a>>) -> bool,
+        F: FnMut(&Node<'a>) -> bool,
     {
+        let parser = self.parser();
+
         for node in self.children() {
-            if let Some(node) = node.find_node(&mut f) {
-                return Some(node);
+            let node = node.get(parser).and_then(|x| x.find_node(parser, &mut f));
+
+            if node.is_some() {
+                return node;
             }
         }
 

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -1,5 +1,5 @@
-use crate::parser::handle::NodeHandle;
 use crate::parser::ClassVec;
+use crate::parser::NodeHandle;
 use crate::{bytes::AsBytes, parser::HTMLVersion};
 use crate::{Node, Parser};
 use std::marker::PhantomData;
@@ -44,7 +44,15 @@ impl<'a> VDom<'a> {
         self.parser.classes.get(&id.as_bytes())
     }
 
-    /// Returns all subnodes ("children") of this DOM
+    /// Returns a slice of *all* the elements in the HTML document
+    ///
+    /// The difference between `children()` and `nodes()` is that children only returns the immediate children of the root node,
+    /// while `nodes()` returns all nodes, including nested tags.
+    pub fn nodes(&self) -> &[Node<'a>] {
+        &self.parser.tags
+    }
+
+    /// Returns the topmost subnodes ("children") of this DOM
     pub fn children(&self) -> &[NodeHandle] {
         &self.parser.ast
     }
@@ -59,6 +67,10 @@ impl<'a> VDom<'a> {
     ///
     /// The closure must return a boolean, indicating whether it should stop iterating
     /// Returning `true` will break the loop
+    #[deprecated(
+        since = "0.3.0",
+        note = "please use `nodes().iter().find(...)` instead"
+    )]
     pub fn find_node<F>(&self, mut f: F) -> Option<NodeHandle>
     where
         F: FnMut(&Node<'a>) -> bool,


### PR DESCRIPTION
- avoids Rc allocations
- inline vectors to avoid allocating for small collections
- fixes #7
- disable id/class tracking by default

before:
```
tl-throughput/tl        time:   [1.4386 ms 1.4425 ms 1.4461 ms]
                        thrpt:  [216.29 MiB/s 216.84 MiB/s 217.42 MiB/s]
```

after:
```
tl-throughput/tl        time:   [743.77 us 744.32 us 744.88 us]
                        thrpt:  [419.91 MiB/s 420.22 MiB/s 420.53 MiB/s]
```