### PR TITLE
Slash tag bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changes annotated with `⚠` are breaking.
 
+# 0.6.2
+- Fixes a bug where the slash in slash tags (`<br />`) is interpreted as `>` and causes the next `>` to be interpreted as a text node on its own.
+
 # 0.6.1
 - Fixed an off-by-one error in the `QueryIterable` trait implementation for `HTMLTag` that caused query selectors on HTML tags to return one node less than they should.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tl"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["y21"]
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ tl is a fast HTML parser written in pure Rust. <br />
 Add `tl` to your dependencies.
 ```toml
 [dependencies]
-tl = "0.6.1"
+tl = "0.6.2"
 # or, if you need SIMD
-tl = { version = "0.6.1", features = ["simd"] }
+# (requires a nightly compiler!)
+tl = { version = "0.6.2", features = ["simd"] }
 ```
 
 The main function is `tl::parse()`. It accepts an HTML source code string and parses it. It is important to note that tl currently silently ignores tags that are invalid, sort of like browsers do. Sometimes, this means that large chunks of the HTML document do not appear in the resulting AST, although in the future this will likely be customizable, in case you need explicit error checking.

--- a/src/parser/base.rs
+++ b/src/parser/base.rs
@@ -325,6 +325,8 @@ impl<'a> Parser<'a> {
 
                 let attr = self.parse_attributes()?;
 
+                let is_self_closing = self.stream.expect_and_skip_cond(b'/');
+
                 self.stream.advance(); // skip >
 
                 let this = self.register_tag(Node::Tag(HTMLTag::new(
@@ -340,7 +342,7 @@ impl<'a> Parser<'a> {
                 // we don't always want to push them to the stack
                 // e.g. <br><p>Hello</p>
                 // <p> should not be a subtag of <br>
-                if !constants::VOID_TAGS.contains(&name) {
+                if !is_self_closing && !constants::VOID_TAGS.contains(&name) {
                     self.stack.push(this);
                 }
             }

--- a/src/queryselector/parser.rs
+++ b/src/queryselector/parser.rs
@@ -16,7 +16,7 @@ impl<'a> Parser<'a> {
     }
 
     fn skip_whitespaces(&mut self) -> bool {
-        let has_whitespace = self.stream.expect_and_skip(b' ').is_some();
+        let has_whitespace = self.stream.expect_and_skip_cond(b' ');
         while !self.stream.is_eof() {
             if self.stream.expect_and_skip(b' ').is_none() {
                 break;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -20,9 +20,17 @@ impl<'a, T: Eq + Copy> Stream<'a, T> {
     /// If it does match, the expected character is returned
     #[inline]
     pub fn expect_and_skip(&mut self, expect: T) -> Option<T> {
-        self.expect_oneof_and_skip(&[expect])
+        let c = self.current_cpy()?;
+        if c == expect {
+            self.advance();
+            Some(c)
+        } else {
+            None
+        }
     }
 
+    /// Increases internal index by 1 if any of the given elements match the current element
+    /// If it does match, the expected character is returned
     pub fn expect_oneof_and_skip(&mut self, expect: &[T]) -> Option<T> {
         let c = self.current_cpy()?;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -599,3 +599,12 @@ fn assert_length() {
     assert_len("<div><a><a></a></a></div>", "a", 2);
     assert_len("<div><a><span></span></a></div>", "span", 1);
 }
+
+#[test]
+fn self_closing_no_child() {
+    let dom = parse("<br /><p>test</p>", Default::default()).unwrap();
+    let nodes = dom.nodes();
+    assert_eq!(nodes.len(), 3);
+    assert_eq!(nodes[0].as_tag().unwrap()._children.len(), 0);
+    assert_eq!(nodes[0].as_tag().unwrap().raw(), "<br />");
+}


### PR DESCRIPTION
Fixes a bug where the slash in slash tags (`<br />`) is interpreted as `>` and causes the next `>` to be interpreted as a text node on its own.
```html
<br /><p></p>
```
is parsed as `[br, ">", p]`