### PR TITLE
[Merged by Bors] - fix Attributes::insert and add HTMLTag::boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,19 @@
 Changes annotated with `⚠` are breaking.
 
+# 0.7.0
+> **Warning: This release contains breaking changes**
+- ⚠ Function signature of `Attributes::insert` has changed:
+    - It now takes two generic parameters `K, V` instead of just one.
+    Prior to this version, this meant that the key and value type had to match.
+    See [y21/tl#27](https://github.com/y21/tl/pull/26) for more details.
+- Added a `TryFrom<String> for Bytes` implementation for convenience to create owned `Bytes`.
+- Added `HTMLTag::boundaries` method for obtaining the start and end position of a tag in the source string.
+
 # 0.6.3
-- Fixes a bug where `Attributes::class()` returned its id attribute instead of class. See [y21/tl#26](https://github.com/y21/tl/pull/26)
+- Fixed a bug where `Attributes::class()` returned its id attribute instead of class. See [y21/tl#26](https://github.com/y21/tl/pull/26)
 
 # 0.6.2
-- Fixes a bug where the slash in slash tags (`<br />`) is interpreted as `>` and causes the next `>` to be interpreted as a text node on its own.
+- Fixed a bug where the slash in slash tags (`<br />`) is interpreted as `>` and causes the next `>` to be interpreted as a text node on its own.
 
 # 0.6.1
 - Fixed an off-by-one error in the `QueryIterable` trait implementation for `HTMLTag` that caused query selectors on HTML tags to return one node less than they should.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changes annotated with `⚠` are breaking.
     See [y21/tl#27](https://github.com/y21/tl/pull/26) for more details.
 - Added a `TryFrom<String> for Bytes` implementation for convenience to create owned `Bytes`.
 - Added `HTMLTag::boundaries` method for obtaining the start and end position of a tag in the source string.
+- Fixed a panic when source string abruptly ends with `<tag/`
 
 # 0.6.3
 - Fixed a bug where `Attributes::class()` returned its id attribute instead of class. See [y21/tl#26](https://github.com/y21/tl/pull/26)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tl"
-version = "0.6.3"
+version = "0.7.0"
 authors = ["y21"]
 edition = "2021"
 license = "MIT"

--- a/bors.toml
+++ b/bors.toml
@@ -1,1 +1,2 @@
 status = ["Check"]
+use_squash_merge = true

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -104,6 +104,17 @@ impl<'a> From<&'a [u8]> for Bytes<'a> {
     }
 }
 
+impl TryFrom<String> for Bytes<'static> {
+    type Error = SetBytesError;
+
+    #[inline]
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        let mut bytes = Bytes::new();
+        bytes.set(s)?;
+        Ok(bytes)
+    }
+}
+
 /// Converts `Bytes` raw parts to a slice
 #[inline]
 unsafe fn compact_bytes_to_slice<'a>(ptr: *const u8, l: u32) -> &'a [u8] {

--- a/src/parser/base.rs
+++ b/src/parser/base.rs
@@ -327,7 +327,7 @@ impl<'a> Parser<'a> {
 
                 let is_self_closing = self.stream.expect_and_skip_cond(b'/');
 
-                self.stream.advance(); // skip >
+                self.stream.expect_and_skip(b'>')?;
 
                 let this = self.register_tag(Node::Tag(HTMLTag::new(
                     name.into(),

--- a/src/parser/tag.rs
+++ b/src/parser/tag.rs
@@ -91,9 +91,10 @@ impl<'a> Attributes<'a> {
     }
 
     /// Inserts a new attribute into this attributes collection
-    pub fn insert<B>(&mut self, key: B, value: Option<B>)
+    pub fn insert<K, V>(&mut self, key: K, value: Option<V>)
     where
-        B: Into<Bytes<'a>>,
+        K: Into<Bytes<'a>>,
+        V: Into<Bytes<'a>>,
     {
         let key: Bytes = key.into();
         let value = value.map(Into::into);
@@ -264,6 +265,25 @@ impl<'a> HTMLTag<'a> {
     /// This simply returns a reference to the substring.
     pub fn raw(&self) -> &Bytes<'a> {
         &self._raw
+    }
+
+    /// Returns the boundaries/position `(start, end)` of this HTML tag in the source string.
+    ///
+    /// ## Example
+    /// ```
+    /// let dom = tl::parse("<p><span>hello</span></p>", Default::default()).unwrap();
+    /// let parser = dom.parser();
+    /// let span = dom.nodes().iter().filter_map(|n| n.as_tag()).find(|n| n.name() == "span").unwrap();
+    /// let (start, end) = span.boundaries(parser);
+    /// assert_eq!((start, end), (3, 20));
+    /// ```
+    pub fn boundaries(&self, parser: &Parser<'a>) -> (usize, usize) {
+        let raw = self._raw.as_bytes();
+        let input = parser.stream.data().as_ptr();
+        let start = raw.as_ptr();
+        let offset = start as usize - input as usize;
+        let end = offset + raw.len();
+        (offset, end)
     }
 
     /// Returns the contained text of this element, excluding any markup

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{parse, parse_owned};
+use crate::{parse, parse_owned, Bytes};
 use crate::{parser::*, HTMLTag, Node};
 
 fn force_as_tag<'a, 'b>(actual: &'a Node<'b>) -> &'a HTMLTag<'b> {
@@ -607,4 +607,22 @@ fn self_closing_no_child() {
     assert_eq!(nodes.len(), 3);
     assert_eq!(nodes[0].as_tag().unwrap()._children.len(), 0);
     assert_eq!(nodes[0].as_tag().unwrap().raw(), "<br />");
+}
+
+#[test]
+fn insert_attribute_owned() {
+    // https://github.com/y21/tl/issues/27
+    let mut attr = Attributes::new();
+    let style = "some style".to_string();
+    attr.insert("style", Some(Bytes::try_from(style).unwrap()));
+    assert_eq!(attr.get("style"), Some(Some(&"some style".into())));
+}
+
+#[test]
+fn boundaries() {
+    // https://github.com/y21/tl/issues/25
+    let dom = parse("<div><p>haha</p></div>", Default::default()).unwrap();
+    let span = dom.nodes()[1].as_tag().unwrap();
+    let boundary = span.boundaries(dom.parser());
+    assert_eq!(boundary, (5, 15));
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -192,6 +192,7 @@ fn fuzz() {
     // We don't need to assert anything here, just see that they finish
     parse("J\x00<", ParserOptions::default()).unwrap();
     parse("<!J", ParserOptions::default()).unwrap();
+    parse("<=/Fy<=/", Default::default()).unwrap();
 
     // Miri is too slow... :(
     let count = if cfg!(miri) { 100usize } else { 10000usize };


### PR DESCRIPTION
Fixes #25 and fixes #27 . See `CHANGELOG.md` for changes.