### PR TITLE
[Merged by Bors] - Fix for correctly parsing closing tags

### DIFF
--- a/src/parser/base.rs
+++ b/src/parser/base.rs
@@ -215,22 +215,20 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn read_end(&mut self) -> Option<()> {
+    fn read_end(&mut self) {
         self.stream.advance();
 
-        let closing_tag_name = self.read_ident()?;
-
-        self.read_to(b'>');
+        let closing_tag_name = self.read_to(b'>');
+        
         self.stream.expect_and_skip_cond(b'>');
 
         let closing_tag_matches_parent = self.stack.last()
             .and_then(|last_handle| last_handle.get(self))
             .and_then(|last_item| last_item.as_tag())
-            .and_then(|last_tag| Some(last_tag.name() == closing_tag_name))
-            .unwrap_or(false);
+            .map_or(false, |last_tag| last_tag.name() == closing_tag_name);
 
         if !closing_tag_matches_parent {
-            return None
+            return;
         }
 
         if let Some(handle) = self.stack.pop() {
@@ -272,8 +270,6 @@ impl<'a> Parser<'a> {
                 self.ids.insert(bytes.clone(), handle);
             }
         }
-
-        Some(())
     }
 
     #[cold]
@@ -322,7 +318,7 @@ impl<'a> Parser<'a> {
         let cur = self.stream.current_cpy()?;
 
         match cur {
-            b'/' => self.read_end()?,
+            b'/' => self.read_end(),
             b'!' => {
                 self.read_markdown();
             }

--- a/src/parser/base.rs
+++ b/src/parser/base.rs
@@ -216,10 +216,7 @@ impl<'a> Parser<'a> {
     }
 
     fn read_end(&mut self) -> Option<()> {
-        self.read_to(b'/');
         self.stream.advance();
-
-        self.skip_whitespaces();
 
         let closing_tag_name = self.read_ident()?;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -103,14 +103,19 @@ fn ignore_void_closing_tags() {
     let input = r#"
         <head>
             <base href='single_quoted_item'></base>
+            <link rel="stylesheet" type="text/css" href="non-exising"/>
         </head>
     "#;
 
     let dom = parse(input, ParserOptions::default()).unwrap();
     let head_tag = force_as_tag(dom.children()[1].get(dom.parser()).unwrap());
 
+    let base_tag = force_as_tag(head_tag.children().top()[1].get(dom.parser()).unwrap());
+    let link_tag = force_as_tag(head_tag.children().top()[3].get(dom.parser()).unwrap());
+
     assert_eq!(head_tag.name(), "head");
-    assert_eq!(head_tag.children().top().len(), 3) // 3 newlines, but no base tag
+    assert_eq!(base_tag.name(), "base");
+    assert_eq!(link_tag.name(), "link");
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -99,6 +99,21 @@ fn html5() {
 }
 
 #[test]
+fn ignore_void_closing_tags() {
+    let input = r#"
+        <head>
+            <base href='single_quoted_item'></base>
+        </head>
+    "#;
+
+    let dom = parse(input, ParserOptions::default()).unwrap();
+    let head_tag = force_as_tag(dom.children()[1].get(dom.parser()).unwrap());
+
+    assert_eq!(head_tag.name(), "head");
+    assert_eq!(head_tag.children().top().len(), 3) // 3 newlines, but no base tag
+}
+
+#[test]
 fn nested_inner_text() {
     let dom = parse(
         "<p>hello <p>nested element</p></p>",


### PR DESCRIPTION
Fixes #37 

This pull request fixes the issue where void closing tags would not be ignored. Causing the closing tag to close the parent instead of the voided tag.

To implement this, I had to also fix the ``tag_raw_abrupt_stop`` test. Because this would not treat the ``eof`` as a valid end of a identifier. Causing the identifier parsing of the closing tag to fail.