### PR TITLE
[Merged by Bors] - 0.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 Changes annotated with `⚠` are breaking.
 
+# 0.7.6
+- Fixes a build error if compiled with the `simd` feature flag. See [y21/tl#41](https://github.com/y21/tl/issues/41) for more details.
+- In prior versions, `innerHTML()` actually had the behavior of `Element#outerHTML`. This was changed and `innerHTML` now correctly only returns the markup of its subnodes, and not the markup of the own node.
+- `outerHTML()` was added to nodes, which moves the old behavior to another function.
+- Added `children_mut()`, which allows mutating the subnodes of an HTML Tag.
+
 # 0.7.5
 - Fixed a bug that caused the parser to parse closing tags incorrectly. See [y21/tl#37](https://github.com/y21/tl/issues/37) and [y21/tl#38](https://github.com/y21/tl/pull/38) for more details.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tl"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["y21"]
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ If you need a parser that closely follows the standard, consider using [html5eve
 Add `tl` to your dependencies.
 ```toml
 [dependencies]
-tl = "0.7.5"
+tl = "0.7.6"
 # or, with explicit SIMD support
 # (requires a nightly compiler!)
-tl = { version = "0.7.5", features = ["simd"] }
+tl = { version = "0.7.6", features = ["simd"] }
 ```
 
 The main function is `tl::parse()`. It accepts an HTML source code string and parses it. It is important to note that tl currently silently ignores tags that are invalid, sort of like browsers do. Sometimes, this means that large chunks of the HTML document do not appear in the resulting tree.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,9 +82,6 @@ pub fn parse_query_selector(input: &str) -> Option<Selector<'_>> {
 /// The given input string is first leaked and turned into raw pointer, and its lifetime will be promoted to 'static.
 /// Once `VDomGuard` goes out of scope, the string will be freed.
 /// It should not be possible to cause UB in its current form and might become a safe function in the future.
-pub unsafe fn parse_owned<'a>(
-    input: String,
-    options: ParserOptions,
-) -> Result<VDomGuard<'a>, ParseError> {
+pub unsafe fn parse_owned(input: String, options: ParserOptions) -> Result<VDomGuard, ParseError> {
     VDomGuard::parse(input, options)
 }

--- a/src/parser/tag.rs
+++ b/src/parser/tag.rs
@@ -250,6 +250,11 @@ impl<'a> HTMLTag<'a> {
         Children(self)
     }
 
+    /// Returns a mutable wrapper around the children of this HTML tag.
+    pub fn children_mut(&mut self) -> ChildrenMut<'a, '_> {
+        ChildrenMut(self)
+    }
+
     /// Returns the name of this HTML tag
     #[inline]
     pub fn name(&self) -> &Bytes<'a> {
@@ -555,6 +560,20 @@ impl<'a, 'b> Children<'a, 'b> {
         self.boundaries(parser)
             .map(|(start, end)| &parser.tags[start as usize..=end as usize])
             .unwrap_or(&[])
+    }
+}
+
+/// A thin mutable wrapper around the children of [`HTMLTag`]
+#[derive(Debug)]
+pub struct ChildrenMut<'a, 'b>(&'b mut HTMLTag<'a>);
+
+impl<'a, 'b> ChildrenMut<'a, 'b> {
+    /// Returns the topmost, direct children of this tag as a mutable slice.
+    ///
+    /// See [`Children::top`] for more details and examples.
+    #[inline]
+    pub fn top_mut(&mut self) -> &mut RawChildren {
+        &mut self.0._children
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -9,13 +9,31 @@ fn force_as_tag<'a, 'b>(actual: &'a Node<'b>) -> &'a HTMLTag<'b> {
 }
 
 #[test]
-fn inner_html() {
-    let dom = parse("abc <p>test</p> def", ParserOptions::default()).unwrap();
+fn outer_html() {
+    let dom = parse(
+        "abc <p>test<span>a</span></p> def",
+        ParserOptions::default(),
+    )
+    .unwrap();
     let parser = dom.parser();
 
     let tag = force_as_tag(dom.children()[1].get(parser).unwrap());
 
-    assert_eq!(tag.inner_html(parser), "<p>test</p>");
+    assert_eq!(tag.outer_html(parser), "<p>test<span>a</span></p>");
+}
+
+#[test]
+fn inner_html() {
+    let dom = parse(
+        "abc <p>test<span>a</span></p> def",
+        ParserOptions::default(),
+    )
+    .unwrap();
+    let parser = dom.parser();
+
+    let tag = force_as_tag(dom.children()[1].get(parser).unwrap());
+
+    assert_eq!(tag.inner_html(parser), "test<span>a</span>");
 }
 
 #[test]
@@ -41,7 +59,7 @@ fn get_element_by_id_default() {
 
     let el = force_as_tag(tag.get(dom.parser()).unwrap());
 
-    assert_eq!(el.inner_html(parser), "<p id=\"test\"></p>")
+    assert_eq!(el.outer_html(parser), "<p id=\"test\"></p>")
 }
 
 #[test]
@@ -57,7 +75,7 @@ fn get_element_by_id_tracking() {
 
     let el = force_as_tag(tag.get(dom.parser()).unwrap());
 
-    assert_eq!(el.inner_html(parser), "<p id=\"test\"></p>")
+    assert_eq!(el.outer_html(parser), "<p id=\"test\"></p>")
 }
 
 #[test]
@@ -659,7 +677,7 @@ fn attributes_remove_inner_html() {
         .attributes_mut()
         .remove_value("contenteditable");
 
-    assert_eq!(dom.inner_html(), "<span contenteditable>testing</span>");
+    assert_eq!(dom.outer_html(), "<span contenteditable>testing</span>");
 
     dom.nodes_mut()[0]
         .as_tag_mut()
@@ -667,7 +685,7 @@ fn attributes_remove_inner_html() {
         .attributes_mut()
         .remove("contenteditable");
 
-    assert_eq!(dom.inner_html(), "<span>testing</span>");
+    assert_eq!(dom.outer_html(), "<span>testing</span>");
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -137,6 +137,28 @@ fn ignore_void_closing_tags() {
 }
 
 #[test]
+pub fn children_mut() {
+    let input = "<head><p>Replace me</p> World</head>";
+
+    let mut dom = parse(input, Default::default()).unwrap();
+    let children = dom.children();
+    let child = children[0]
+        .clone()
+        .get_mut(dom.parser_mut())
+        .unwrap()
+        .as_tag_mut()
+        .unwrap();
+
+    let mut children = child.children_mut();
+    let top = children.top_mut();
+    let handle = top[0].clone();
+    let node = handle.get_mut(dom.parser_mut()).unwrap();
+    *node = Node::Raw("Hello".into());
+
+    assert_eq!(dom.outer_html(), "<head>Hello World</head>");
+}
+
+#[test]
 fn nested_inner_text() {
     let dom = parse(
         "<p>hello <p>nested element</p></p>",

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -131,6 +131,8 @@ impl<'a> VDom<'a> {
 
     /// Returns the contained markup of all of the elements in this DOM.
     ///
+    /// Equivalent to [Element#outerHTML](https://developer.mozilla.org/en-US/docs/Web/API/Element/outerHTML) in browsers)
+    ///
     /// # Example
     /// ```
     /// let html = r#"<div><p href="/about" id="find-me">Hello world</p></div>"#;
@@ -145,14 +147,14 @@ impl<'a> VDom<'a> {
     ///
     /// element.attributes_mut().get_mut("href").flatten().unwrap().set("/");
     ///
-    /// assert_eq!(dom.inner_html(), r#"<div><p href="/" id="find-me">Hello world</p></div>"#);
+    /// assert_eq!(dom.outer_html(), r#"<div><p href="/" id="find-me">Hello world</p></div>"#);
     /// ```
-    pub fn inner_html(&self) -> String {
+    pub fn outer_html(&self) -> String {
         let mut inner_html = String::with_capacity(self.parser.stream.len());
 
         for node in self.children() {
             let node = node.get(&self.parser).unwrap();
-            inner_html.push_str(&node.inner_html(&self.parser));
+            inner_html.push_str(&node.outer_html(&self.parser));
         }
 
         inner_html

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -184,29 +184,26 @@ impl<'a> VDom<'a> {
 /// The input string is freed once this struct goes out of scope.
 /// The only way to construct this is by calling `parse_owned()`.
 #[derive(Debug)]
-pub struct VDomGuard<'a> {
+pub struct VDomGuard {
     /// Wrapped VDom instance
-    dom: VDom<'a>,
+    dom: VDom<'static>,
     /// The leaked input string that is referenced by self.dom
     _s: RawString,
     /// PhantomData for self.dom
-    _phantom: PhantomData<&'a str>,
+    _phantom: PhantomData<&'static str>,
 }
 
-unsafe impl<'a> Send for VDomGuard<'a> {}
-unsafe impl<'a> Sync for VDomGuard<'a> {}
+unsafe impl Send for VDomGuard {}
+unsafe impl Sync for VDomGuard {}
 
-impl<'a> VDomGuard<'a> {
+impl VDomGuard {
     /// Parses the input string
-    pub(crate) fn parse(
-        input: String,
-        options: ParserOptions,
-    ) -> Result<VDomGuard<'a>, ParseError> {
+    pub(crate) fn parse(input: String, options: ParserOptions) -> Result<VDomGuard, ParseError> {
         let input = RawString::new(input);
 
         let ptr = input.as_ptr();
 
-        let input_ref: &'a str = unsafe { &*ptr };
+        let input_ref: &'static str = unsafe { &*ptr };
 
         // Parsing will either:
         // a) succeed, and we return a VDom instance
@@ -224,18 +221,18 @@ impl<'a> VDomGuard<'a> {
     }
 }
 
-impl<'a> VDomGuard<'a> {
+impl VDomGuard {
     /// Returns a reference to the inner DOM.
     ///
     /// The lifetime of the returned `VDom` is bound to self so that elements cannot outlive this `VDomGuard` struct.
-    pub fn get_ref<'b>(&'a self) -> &'b VDom<'a> {
+    pub fn get_ref<'a>(&'a self) -> &'a VDom<'a> {
         &self.dom
     }
 
     /// Returns a mutable reference to the inner DOM.
     ///
     /// The lifetime of the returned `VDom` is bound to self so that elements cannot outlive this `VDomGuard` struct.
-    pub fn get_mut_ref<'b>(&'b mut self) -> &'b VDom<'a> {
+    pub fn get_mut_ref<'a, 'b: 'a>(&'b mut self) -> &'b VDom<'a> {
         &mut self.dom
     }
 }


### PR DESCRIPTION
## Changes

- Fixes a build error if compiled with the `simd` feature flag ( #41 )
- In prior versions, `innerHTML()` actually had the behavior of `Element#outerHTML`. This was changed and `innerHTML` now correctly only returns the markup of its subnodes, and not the markup of the own node. ( #39 )
- `outerHTML()` was added to nodes, which moves the old behavior to another function. ( # 39 )
- Added `children_mut()`, which allows mutating the subnodes of an HTML Tag. ( #40 )
- Fixes the `parse_owned()` function and `VDomGuard` struct to not have unbound lifetimes.