### PR TITLE
We need to add two more symbols for link types

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -6,6 +6,8 @@ pub fn is_ident(c: u8) -> bool {
         || c == b'-'
         || c == b'_'
         || c == b':'
+        || c == b'+'
+        || c == b'/'
 }
 
 #[inline(always)]


### PR DESCRIPTION
Sorry for opening a pr again for a similar situation. There are symbols required for link types such as atom and rss.

Example
```
<link rel="alternate" type="application/rss+xml" href="rss.xml" title="RSS 2.0">
<link rel="alternate" type="application/atom+xml" href="rss.xml" title="Atom 1.0">
```