### PR TITLE
Fix void elements having closing tags

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -23,6 +23,16 @@ fn outer_html() {
 }
 
 #[test]
+fn outer_html_void_elements() {
+    const HTML_INPUT: &str = r#"<html><head></head><body><img src=""><br><hr></body></html>"#;
+    let vdom = parse(HTML_INPUT, ParserOptions::default()).unwrap();
+    assert_eq!(
+        r#"<html><head></head><body><img src=""><br><hr></body></html>"#,
+        vdom.outer_html()
+    );
+}
+
+#[test]
 fn inner_html() {
     let dom = parse(
         "abc <p>test<span>a</span></p> def",


### PR DESCRIPTION
HTML defines certain elements as "void elements"
> A void element is an element whose [content model](https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#content-model) never allows it to have [contents](https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#contents) under any circumstances. Void elements can have attributes.
> 
> The following is a complete list of the void elements in HTML:
> 
> [area](https://www.w3.org/TR/2011/WD-html-markup-20110113/area.html#area), [base](https://www.w3.org/TR/2011/WD-html-markup-20110113/base.html#base), [br](https://www.w3.org/TR/2011/WD-html-markup-20110113/br.html#br), [col](https://www.w3.org/TR/2011/WD-html-markup-20110113/col.html#col), [command](https://www.w3.org/TR/2011/WD-html-markup-20110113/command.html#command), [embed](https://www.w3.org/TR/2011/WD-html-markup-20110113/embed.html#embed), [hr](https://www.w3.org/TR/2011/WD-html-markup-20110113/hr.html#hr), [img](https://www.w3.org/TR/2011/WD-html-markup-20110113/img.html#img), [input](https://www.w3.org/TR/2011/WD-html-markup-20110113/input.html#input), [keygen](https://www.w3.org/TR/2011/WD-html-markup-20110113/keygen.html#keygen), [link](https://www.w3.org/TR/2011/WD-html-markup-20110113/link.html#link), [meta](https://www.w3.org/TR/2011/WD-html-markup-20110113/meta.html#meta), [param](https://www.w3.org/TR/2011/WD-html-markup-20110113/param.html#param), [source](https://www.w3.org/TR/2011/WD-html-markup-20110113/source.html#source), [track](https://www.w3.org/TR/2011/WD-html-markup-20110113/track.html#track), [wbr](https://www.w3.org/TR/2011/WD-html-markup-20110113/wbr.html#wbr)

And further it states:
> [Void elements](https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#void-element) only have a start tag; end tags [must](https://www.w3.org/TR/2011/WD-html-markup-20110113/terminology.html#must-requirement) not be specified for void elements.

But the current implementation of the HTML serialisation does not follow this rule. Test / Example:
```rust
#[test]
fn self_closing_tags() {
    const HTML_INPUT: &str = r#"<html><head></head><body><img src=""><br><hr></body></html>"#;
    let vdom = tl::parse(HTML_INPUT, tl::ParserOptions::default()).unwrap();
    assert_eq!(
        r#"<html><head></head><body><img src=""><br><hr></body></html>"#,
        vdom.outer_html()
    );
}
```

Result:
```
---- self_closing_tags stdout ----
thread 'self_closing_tags' panicked at 'assertion failed: `(left == right)`
  left: `"<html><head></head><body><img src=\"\"><br><hr></body></html>"`,
 right: `"<html><head></head><body><img src=\"\"></img><br></br><hr></hr></body></html>"`'
```


This PR adds a check to see if the element is a void element and thus skips content & end tag serialization