### PR TITLE
Update nightly SIMD impl after std::simd::cmp::* changes

### DIFF
--- a/src/simd/nightly.rs
+++ b/src/simd/nightly.rs
@@ -1,4 +1,4 @@
-use std::{ptr, simd::*};
+use std::{ptr, simd::*, simd::cmp::{SimdPartialEq,  SimdPartialOrd}};
 
 use crate::simd::fallback;
 


### PR DESCRIPTION
`tl` no longer builds on the latest nightly without these imports in `simd::nightly`.