### PR TITLE
Fix precedence for descendant and parent selectors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ pub fn parse(input: &str, options: ParserOptions) -> Result<VDom<'_>, ParseError
 /// }
 /// ```
 pub fn parse_query_selector(input: &str) -> Option<Selector<'_>> {
-    let selector = queryselector::Parser::new(input.as_bytes()).selector()?;
+    let selector = queryselector::Parser::new(input.as_bytes()).parse_selectors_group()?;
     Some(selector)
 }
 


### PR DESCRIPTION
Fixes #54 by aligning the parsing of query selectors to the [Selectors Level 3 Recommendations]. Also adds tests for query selector parsing to verify the updated behavior.

[Selectors Level 3 Recommendations]: https://www.w3.org/TR/selectors-3/