### PR TITLE
Handle whitespace inside closing tags

### DIFF
--- a/src/parser/base.rs
+++ b/src/parser/base.rs
@@ -217,17 +217,23 @@ impl<'a> Parser<'a> {
 
     fn read_end(&mut self) {
         self.stream.advance();
+        self.skip_whitespaces();
 
-        let closing_tag_name = self.read_to(b'>');
-        
-        self.stream.expect_and_skip_cond(b'>');
+        if let Some(closing_tag_name) = self.read_ident() {
+            self.skip_whitespaces();
+            self.stream.expect_and_skip_cond(b'>');
 
-        let closing_tag_matches_parent = self.stack.last()
-            .and_then(|last_handle| last_handle.get(self))
-            .and_then(|last_item| last_item.as_tag())
-            .map_or(false, |last_tag| last_tag.name() == closing_tag_name);
+            let closing_tag_matches_parent = self
+                .stack
+                .last()
+                .and_then(|last_handle| last_handle.get(self))
+                .and_then(|last_item| last_item.as_tag())
+                .map_or(false, |last_tag| last_tag.name() == closing_tag_name);
 
-        if !closing_tag_matches_parent {
+            if !closing_tag_matches_parent {
+                return;
+            }
+        } else {
             return;
         }
 


### PR DESCRIPTION
Fixes #65 by adding a skip whitespace before and after the name of a closing tag. Also adds a test to verify that this functions properly, based on the example in #65.

Note that the [HTML spec] does not allow for whitespace between the `</` and the tag name, although this is accepted by these changes to maintain symmetry with the parsing of the start of a tag which started allowing whitespace between `<` and the tag name in c532c72.

[HTML spec]: https://html.spec.whatwg.org/multipage/syntax.html#end-tags