### PR TITLE
Made VDomGuard::get_mut_ref actually return a mutable ref

### DIFF
--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -232,7 +232,8 @@ impl VDomGuard {
     /// Returns a mutable reference to the inner DOM.
     ///
     /// The lifetime of the returned `VDom` is bound to self so that elements cannot outlive this `VDomGuard` struct.
-    pub fn get_mut_ref<'a, 'b: 'a>(&'b mut self) -> &'b mut VDom<'a> {
+    pub fn get_mut_ref(&mut self) -> &mut VDom<'static>
+    {
         &mut self.dom
     }
 }

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -232,7 +232,7 @@ impl VDomGuard {
     /// Returns a mutable reference to the inner DOM.
     ///
     /// The lifetime of the returned `VDom` is bound to self so that elements cannot outlive this `VDomGuard` struct.
-    pub fn get_mut_ref<'a, 'b: 'a>(&'b mut self) -> &'b VDom<'a> {
+    pub fn get_mut_ref<'a, 'b: 'a>(&'b mut self) -> &'b mut VDom<'a> {
         &mut self.dom
     }
 }


### PR DESCRIPTION
It's such a small fix that it might be easier to just fix it yourself than try to merge a PR but here you go.

The method now returns a `&mut VDom<'static>`. The lifetimes should be fine since even though the returned `VDom` is static the mutable reference to it will drop before the guard drops. Ensuring that the mutable reference returned will not outlive the guard.

Fixes #71