### PR TITLE
Specify broader lifetime for Children::top() result

### DIFF
--- a/src/parser/tag.rs
+++ b/src/parser/tag.rs
@@ -518,7 +518,7 @@ impl<'a, 'b> Children<'a, 'b> {
     /// assert_eq!(a.children().top().len(), 3);
     /// ```
     #[inline]
-    pub fn top(&self) -> &RawChildren {
+    pub fn top(&self) -> &'b RawChildren {
         &self.0._children
     }
 


### PR DESCRIPTION
The function `Children::top()` in `parser/tag.rs` returns a reference to `RawChildren` without a specified lifetime, so the lifetime of `&self` is implicitly used. This is too restrictive because the reference points to data which is valid within the potentially broader `'b` lifetime.

This small patch fixes this problem.

The change allows writing (without `unsafe` hacks) for example the following convenience function:

```rust
fn iter_node_children<'a, 'b>(parser: &'b Parser<'a>, node: &'b Node<'a>) -> impl Iterator<Item = &'b Node<'a>> {
    node.children()
        .map(|children| children.top().iter().map(|handle| handle.get(parser).unwrap()))
        .into_iter()
        .flatten()
}
```
