### PR TITLE
Allow `&[u8]` and `Vec<u8>` input

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,11 @@ pub use vdom::{VDom, VDomGuard};
 /// assert_eq!(dom.query_selector("div").unwrap().count(), 1);
 /// ```
 pub fn parse(input: &str, options: ParserOptions) -> Result<VDom<'_>, ParseError> {
+    parse_bytes(input.as_bytes(), options)
+}
+
+/// Same as `parse()`, but with `&[u8]` input.
+pub fn parse_bytes(input: &[u8], options: ParserOptions) -> Result<VDom<'_>, ParseError> {
     let mut parser = Parser::new(input, options);
     parser.parse()?;
     Ok(VDom::from(parser))
@@ -83,5 +88,10 @@ pub fn parse_query_selector(input: &str) -> Option<Selector<'_>> {
 /// Once `VDomGuard` goes out of scope, the string will be freed.
 /// It should not be possible to cause UB in its current form and might become a safe function in the future.
 pub unsafe fn parse_owned(input: String, options: ParserOptions) -> Result<VDomGuard, ParseError> {
+    parse_bytes_owned(input.into_bytes(), options)
+}
+
+/// Same as `parse_owned()`, but with `Vec<u8>` input.
+pub unsafe fn parse_bytes_owned(input: Vec<u8>, options: ParserOptions) -> Result<VDomGuard, ParseError> {
     VDomGuard::parse(input, options)
 }

--- a/src/parser/base.rs
+++ b/src/parser/base.rs
@@ -53,12 +53,12 @@ pub struct Parser<'a> {
 }
 
 impl<'a> Parser<'a> {
-    pub(crate) fn new(input: &str, options: ParserOptions) -> Parser {
+    pub(crate) fn new(input: &[u8], options: ParserOptions) -> Parser {
         Parser {
             stack: Vec::with_capacity(4),
             options,
             tags: Vec::new(),
-            stream: Stream::new(input.as_bytes()),
+            stream: Stream::new(input),
             ast: Vec::new(),
             ids: HashMap::new(),
             classes: HashMap::new(),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{parse, parse_owned, Bytes};
+use crate::{parse, parse_bytes, parse_owned, Bytes};
 use crate::{parser::*, HTMLTag, Node};
 
 fn force_as_tag<'a, 'b>(actual: &'a Node<'b>) -> &'a HTMLTag<'b> {
@@ -777,4 +777,19 @@ fn tag_raw_abrupt_stop() {
 
     let from_raw = first_tag.raw().try_as_utf8_str().unwrap();
     assert_eq!(from_raw, "<p>abcd</p");
+}
+
+#[test]
+fn non_utf8() {
+    let input = b"<p>\xc3\x28</p>".as_ref();
+
+    let vdom = parse_bytes(input, Default::default()).unwrap();
+
+    let first_tag = vdom.children()[0]
+        .get(vdom.parser())
+        .unwrap()
+        .as_tag()
+        .unwrap();
+
+    assert_eq!(first_tag.raw().as_bytes(), b"<p>\xc3\x28</p>");
 }

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -188,9 +188,9 @@ pub struct VDomGuard {
     /// Wrapped VDom instance
     dom: VDom<'static>,
     /// The leaked input string that is referenced by self.dom
-    _s: RawString,
+    _b: RawBytes,
     /// PhantomData for self.dom
-    _phantom: PhantomData<&'static str>,
+    _phantom: PhantomData<&'static [u8]>,
 }
 
 unsafe impl Send for VDomGuard {}
@@ -198,23 +198,23 @@ unsafe impl Sync for VDomGuard {}
 
 impl VDomGuard {
     /// Parses the input string
-    pub(crate) fn parse(input: String, options: ParserOptions) -> Result<VDomGuard, ParseError> {
-        let input = RawString::new(input);
+    pub(crate) fn parse(input: Vec<u8>, options: ParserOptions) -> Result<VDomGuard, ParseError> {
+        let input = RawBytes::new(input);
 
         let ptr = input.as_ptr();
 
-        let input_ref: &'static str = unsafe { &*ptr };
+        let input_ref: &'static [u8] = unsafe { &*ptr };
 
         // Parsing will either:
         // a) succeed, and we return a VDom instance
         //    that, when dropped, will free the input string
         // b) fail, and we return a ParseError
-        //    and `RawString`s destructor will run and deallocate the string properly
+        //    and `RawBytes`s destructor will run and deallocate the string properly
         let mut parser = Parser::new(input_ref, options);
         parser.parse()?;
 
         Ok(Self {
-            _s: input,
+            _b: input,
             dom: VDom::from(parser),
             _phantom: PhantomData,
         })
@@ -238,21 +238,21 @@ impl VDomGuard {
 }
 
 #[derive(Debug)]
-struct RawString(*mut str);
+struct RawBytes(*mut [u8]);
 
-impl RawString {
-    pub fn new(s: String) -> Self {
-        Self(Box::into_raw(s.into_boxed_str()))
+impl RawBytes {
+    pub fn new(s: Vec<u8>) -> Self {
+        Self(Box::into_raw(s.into_boxed_slice()))
     }
 
-    pub fn as_ptr(&self) -> *mut str {
+    pub fn as_ptr(&self) -> *mut [u8] {
         self.0
     }
 }
 
-impl Drop for RawString {
+impl Drop for RawBytes {
     fn drop(&mut self) {
-        // SAFETY: the pointer is always valid because `RawString` can only be constructed through `RawString::new()`
+        // SAFETY: the pointer is always valid because `RawBytes` can only be constructed through `RawBytes::new()`
         unsafe {
             drop(Box::from_raw(self.0));
         };


### PR DESCRIPTION
This library immediately converts `&str` input to `&[u8]` with `as_bytes()` and then does not appear to assume that the input is UTF-8 encoded, in the sense that non-UTF-8 input does not cause any undefined behavior, panics, or an invalid generated DOM. Since there is no `parse()` variant with `&[u8]` input, given such an input to parse, it is necessary to awkwardly use the unsafe `str::from_utf8_unchecked` to avoid unnecessary UTF-8 check overhead.

This pull request:

- changes the type of the `input` parameter of `Parser::new` from `&str` to `&[u8]`,
- changes the type of the `input` parameter of `VDomGuard::new` from `String` to `Vec<u8>` (note that as `String` is backed with `Vec<u8>`, conversion from the former to the latter is cheap),
- changes the type of the pointer stored in `VDomGuard` from `*mut str` to `*mut [u8]`,
- adds new public `parse_bytes()` and `parse_bytes_owned()` functions,
- adds a test for non-UTF-8 input.

Fixes #61.
